### PR TITLE
add cocosAnalytics.isInited interface

### DIFF
--- a/engine/jsb-cocosanalytics.js
+++ b/engine/jsb-cocosanalytics.js
@@ -64,6 +64,9 @@ if (platform === sys.ANDROID) {
             console.error("The arguments passed to cocosAnalytics.init are wrong!");
         }
     };
+    cocosAnalytics.isInited = function() {
+        return jsb.reflection.callStaticMethod(cls_CAAgent, "isInited", "()Z");
+    };
 
     cocosAnalytics.enableDebug = function(enabled) {
         jsb.reflection.callStaticMethod(cls_CAAgent,
@@ -355,6 +358,9 @@ if (platform === sys.ANDROID) {
         }
     };
 
+    cocosAnalytics.isInited = function() {
+        return jsb.reflection.callStaticMethod(cls_CAAgent, "isInited");
+    };
     cocosAnalytics.enableDebug = function(enabled) {
         jsb.reflection.callStaticMethod(cls_CAAgent,
                 "enableDebug:",
@@ -623,6 +629,9 @@ if (platform === sys.ANDROID) {
         console.log("Cocos Analytics module isn't available on this platform!");
     };
 
+    cocosAnalytics.isInited = function() {
+        return false;
+    };
     cocosAnalytics.enableDebug = function(enabled) {
     };
 


### PR DESCRIPTION
`cocosAnalytics.isInited`接口在 cocos2d-x-lite 的 develop 分支存在

PATH `cocos/scripting/js-bindings/script/jsb_cocosanalytics.js`

但是在 jsb-adapter 不存在，这个 PR 增加这个接口