### PR TITLE
Fix can not remove jsb.inputBox first added callback

### DIFF
--- a/builtin/jsb_input.js
+++ b/builtin/jsb_input.js
@@ -29,7 +29,7 @@ var eventTarget = new EventTarget();
 
 var callbackWrappers = {};
 var callbacks = {};
-var index = 0;
+var index = 1;
 var callbackWrapper = function(cb) {
     if (!cb)
     	return null;


### PR DESCRIPTION
## 问题
给 jsb.inputBox 添加的第一个 onConfirm onComplete 或者 onInput 回调方法无法正常移除。
## 原因
例如, 在 offInput 方法中会调用 removeListener, 而最终会先去调用 getCallbackWrapper 获取 callbackWrapper, 在 getCallbackWrapper 方法中, 判断了 cb.__index, 该数值是从 0 开始计数，每次加 1, 当要移除第一个添加的 callback 时候, 当前的 __index 值为 0, 则 getCallbackWrapper 方法返回 null, 无法正常的获取 callbackwrapper。