### PR TITLE
fix load deffered-loaded audio for jsb

### DIFF
--- a/engine/jsb-audio.js
+++ b/engine/jsb-audio.js
@@ -124,7 +124,7 @@ cc.Audio = function (src) {
             if (!clip) {
                 return;
             }
-            path = clip._nativeAsset;
+            path = clip.nativeUrl;
         }
         return audioEngine.play2d(path, loop, volume);
     };


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/8119

native audioEngine 这里不需要考虑 audioClip 是不是已经加载完成，，他这里只需要拿到 audioClip 的  url

@pandamicro 