### PR TITLE
fix jsb-audio with md5

### DIFF
--- a/engine/jsb-audio.js
+++ b/engine/jsb-audio.js
@@ -115,16 +115,16 @@ cc.Audio = function (src) {
             // backward compatibility since 1.10
             cc.warnID(8401, 'cc.audioEngine', 'cc.AudioClip', 'AudioClip', 'cc.AudioClip', 'audio');
             path = clip;
-            var md5Pipe = cc.loader.md5Pipe;
-            if (md5Pipe) {
-                path = md5Pipe.transformURL(path);
-            }
         }
         else {
             if (!clip) {
                 return;
             }
             path = clip.nativeUrl;
+        }
+        var md5Pipe = cc.loader.md5Pipe;
+        if (md5Pipe) {
+            path = md5Pipe.transformURL(path);
         }
         return audioEngine.play2d(path, loop, volume);
     };


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/8175

修复 md5 导致 native audio 不能播放的问题

@knoxHuang 