### PR TITLE
fix jsb-editbox endEditing

### DIFF
--- a/engine/jsb-editbox.js
+++ b/engine/jsb-editbox.js
@@ -79,6 +79,7 @@
 
 	_p.createInput = function() {
 		let editBoxImpl = this;
+		editBoxImpl._editing = true;
 
 		let multiline = this._inputMode === InputMode.ANY;
 		let inputTypeString = getInputType(editBoxImpl._inputMode);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/fireball/issues/8137

修复原生平台 editBox 没有监听 editingDidEnded 事件
http://forum.cocos.com/t/rc2-cocos-creator-v2-0-1/64731/293?u=panda

原因是是 _editing 状态一直是 false, 所以没办法判断编辑是否已经结束