### PR TITLE
Fix require jsb_assets_manager path error

### DIFF
--- a/engine/index.js
+++ b/engine/index.js
@@ -36,4 +36,4 @@ require('jsb-adapter/engine/jsb-loader.js');
 require('jsb-adapter/engine/jsb-editbox.js');
 require('jsb-adapter/engine/jsb-reflection.js');
 require('jsb-adapter/engine/jsb-cocosanalytics.js');
-require('.jsb-adapter/engine/jsb_assets_manager');
+require('jsb-adapter/engine/jsb_assets_manager.js');


### PR DESCRIPTION
requrie jsb_assets_manager.js 时，路径有问题。

已经测试过在 runtime 平台与原生环境中，可以正常运行

@pandamicro