### PR TITLE
fix typo in #32

### DIFF
--- a/engine/jsb-loader.js
+++ b/engine/jsb-loader.js
@@ -195,7 +195,7 @@ cc.loader.addDownloadHandlers({
     'default' : downloadText
 });
 
-cc.loader.addLoaderHandlers({
+cc.loader.addLoadHandlers({
     // Font
     'font' : loadFont,
     'eot' : loadFont,


### PR DESCRIPTION
函数名错误。出错 PR, https://github.com/cocos-creator-packages/jsb-adapter/pull/32

engine 中定义是 “addLoadHandlers” 不是 “addLoaderHandlers”

```
/**
 * Add custom supported types handler or modify existing type handler for load process.
 * @example
 *  cc.loader.addLoadHandlers({
 *      // This will match all url with `.scene` extension or all url with `scene` type
 *      'scene' : function (url, callback) {}
 *  });
 * @method addLoadHandlers
 * @param {Object} extMap Custom supported types with corresponded handler
 */
proto.addLoadHandlers = function (extMap) {
    this.loader.addHandlers(extMap);
};
```