### PR TITLE
fix audio play on runtime

### DIFF
--- a/engine/jsb-loader.js
+++ b/engine/jsb-loader.js
@@ -30,7 +30,11 @@ function downloadScript (item, callback) {
     return null;
 }
 
-function downloadAudio (item, callback) {
+function downloadAudio (item) {
+    return item.url;
+}
+
+function loadAudio (item, callback) {
     var loadByDeserializedAsset = item._owner instanceof cc.AudioClip;
     if (loadByDeserializedAsset) {
         return item.url;
@@ -203,4 +207,11 @@ cc.loader.addLoadHandlers({
     'woff' : loadFont,
     'svg' : loadFont,
     'ttc' : loadFont,
+
+    // Audio
+    'mp3' : loadAudio,
+    'ogg' : loadAudio,
+    'wav' : loadAudio,
+    'mp4' : loadAudio,
+    'm4a' : loadAudio,
 });


### PR DESCRIPTION
- jsb 上统一用 _nativeAsset 播放音频
- 播放之前 确保 audioClip 已经加载完成
- 修改 downloadAudio 为 loadAudio

runtime 测试情况

|  | 延时加载 | 非延时加载 |
| :------:  | :------:  | :------: |
| 本地加载 | √ | √ |
| 远程加载 | √ | √ |

jsb 测试情况

|  | 延时加载 | 非延时加载 |
| :------:  | :------:  | :------: |
| MD5 | √ | √ |
| 非MD5 | √ | √ |