### PR TITLE
Add fileUtils and saveImageData api

### DIFF
--- a/engine/rt-jsb.js
+++ b/engine/rt-jsb.js
@@ -1,11 +1,12 @@
 /****************************************************************************
- Copyright (c) 2018 Xiamen Yaji Software Co., Ltd.
+ Copyright (c) 2013-2016 Chukong Technologies Inc.
+ Copyright (c) 2017-2018 Xiamen Yaji Software Co., Ltd.
 
  http://www.cocos.com
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated engine source code (the "Software"), a limited,
-  worldwide, royalty-free, non-assignable, revocable and non-exclusive license
+  worldwide, royalty-free, non-assignable, revocable and  non-exclusive license
  to use Cocos Creator solely to develop games on your target platforms. You shall
   not use Cocos Creator software for developing other software or tools that's
   used for developing games. You are not granted to publish, distribute,
@@ -22,21 +23,38 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
  ****************************************************************************/
+'use strict';
 
-if (CC_RUNTIME) {
-    require('jsb-adapter/engine/rt-sys.js');
-    require('jsb-adapter/engine/rt_input.js');
-    require('jsb-adapter/engine/rt-loadSubpackage.js');
-    require('jsb-adapter/engine/rt-game.js');
-    require('jsb-adapter/engine/rt-jsb.js');
-} else {
-    require('jsb-adapter/engine/jsb-sys.js');
-    require('jsb-adapter/engine/jsb-game.js');
+var rt = loadRuntime();
+jsb.fileUtils = {
+    getStringFromFile: function (url) {
+        return rt.getFileSystemManager().readFileSync(url, "utf8");
+    },
+
+    getDataFromFile: function (url) {
+        return rt.getFileSystemManager().readFileSync(url);
+    },
+
+    getWritablePath: function () {
+        return `${rt.env.USER_DATA_PATH}/`;
+    },
+
+    writeToFile: function (map, url) {
+        var str = JSON.stringify(map);
+        return rt.getFileSystemManager().writeFileSync(url, str, "utf8")
+    },
+
+    getValueMapFromFile: function (url) {
+        var map_object = {};
+        var read = rt.getFileSystemManager().readFileSync(url, "utf8");
+        if (!read) {
+            return map_object;
+        }
+        map_object = JSON.parse(read);
+        return map_object;
+    },
+};
+
+jsb.saveImageData = function (data, width, height, filePath) {
+    return rt.saveImageData(data, width, height, filePath);
 }
-require('jsb-adapter/engine/jsb-node.js');
-require('jsb-adapter/engine/jsb-audio.js');
-require('jsb-adapter/engine/jsb-loader.js');
-require('jsb-adapter/engine/jsb-editbox.js');
-require('jsb-adapter/engine/jsb-reflection.js');
-require('jsb-adapter/engine/jsb-cocosanalytics.js');
-require('jsb-adapter/engine/jsb-assets-manager.js');


### PR DESCRIPTION
在最新的 creator 测试例中，有使用到了 fileUtils 的相关方法和 saveImageData 方法，所以在 jsb-adapter/engine 中添加对于 runtime 的适配。