### PR TITLE
rename saveImageDataSync, add setPreferredFramesPerSecond in runtime

### DIFF
--- a/engine/rt-jsb.js
+++ b/engine/rt-jsb.js
@@ -56,5 +56,9 @@ jsb.fileUtils = {
 };
 
 jsb.saveImageData = function (data, width, height, filePath) {
-    return rt.saveImageData(data, width, height, filePath);
+    return rt.saveImageDataSync(data, width, height, filePath);
+}
+
+jsb.setPreferredFramesPerSecond = function (fps) {
+    rt.setPreferredFramesPerSecond(fps);
 }


### PR DESCRIPTION
## 修改原因
在 runtime 中

- 将 jsb.setPreferredFramesPerSecond 方法移除。
- 将 saveImageData 方法名修改为 saveImageDataSync。