### PR TITLE
implement saveImageData in adapter

### DIFF
--- a/engine/rt-jsb.js
+++ b/engine/rt-jsb.js
@@ -56,7 +56,25 @@ jsb.fileUtils = {
 };
 
 jsb.saveImageData = function (data, width, height, filePath) {
-    return rt.saveImageDataSync(data, width, height, filePath);
+    var index = filePath.lastIndexOf(".");
+    if (index === -1) {
+        return false;
+    }
+    var fileType = filePath.substr(index + 1);
+    var tempFilePath = rt.saveImageTempSync({
+        'data': data,
+        'width': width,
+        'height': height,
+        'fileType': fileType,
+    });
+    if (tempFilePath === '') {
+        return false;
+    }
+    var savedFilePath = rt.getFileSystemManager().saveFileSync(tempFilePath, filePath);
+    if (savedFilePath === filePath) {
+        return true;
+    }
+    return false;
 }
 
 jsb.setPreferredFramesPerSecond = function (fps) {


### PR DESCRIPTION
## 修改原因
在 runtime 中，只提供最基本的 saveImageTemp 与 saveImageTempSync，而 saveImageData 函数可通过以上两个函数，配合 saveFile 与 saveFileSync 函数实现，所以将 saveImageData 的实现移动到 jsb-adapter 中。