### PR TITLE
runtime require: redo unfinished canvas method

### DIFF
--- a/builtin/jsb-adapter/HTMLCanvasElement.js
+++ b/builtin/jsb-adapter/HTMLCanvasElement.js
@@ -106,12 +106,41 @@ class HTMLCanvasElement extends HTMLElement {
 }
 
 var ctx2DProto = CanvasRenderingContext2D.prototype;
-ctx2DProto.createImageData = function(width, height) {
-    return new ImageData(width, height);
+
+// ImageData ctx.createImageData(imagedata);
+// ImageData ctx.createImageData(width, height);
+ctx2DProto.createImageData = function(imagedata, width, height) {
+    if (typeof imagedata === 'number' && typeof width == 'number') {
+        return new ImageData(imagedata, width);
+    }
+    else if (imagedata instanceof ImageData) {
+        return new imageData(imagedata.data);
+    }
 }
 
-ctx2DProto.putImageData = function(imagedata, dx, dy) {
-    this._canvas._data = imagedata; //REFINE: consider dx, dy?
+// void ctx.putImageData(imagedata, dx, dy);
+// void ctx.putImageData(imagedata, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight);
+ctx2DProto.putImageData = function(imagedata, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight) {
+    var desData = this._canvas._data;
+    var imgData = imageData.data;
+    var height = imageData.height;
+    var width = imageData.width;
+    dirtyX = dirtyX || 0;
+    dirtyY = dirtyY || 0;
+    dirtyWidth = dirtyWidth !== undefined? dirtyWidth: width;
+    dirtyHeight = dirtyHeight !== undefined? dirtyHeight: height;
+    var limitBottom = dirtyY + dirtyHeight;
+    var limitRight = dirtyX + dirtyWidth;
+    for (var y = dirtyY; y < limitBottom; y++) {
+      for (var x = dirtyX; x < limitRight; x++) {
+        var imgPos = y * width + x;
+        var desPos = (y + dy) * this._canvas.width + (x + dx)
+        desData[desPos*4+0] = imgData[imgPos*4+0];
+        desData[desPos*4+1] = imgData[imgPos*4+1];
+        desData[desPos*4+2] = imgData[imgPos*4+2];
+        desData[desPos*4+3] = imgData[imgPos*4+3];
+      }
+    }
 }
 
 ctx2DProto.getImageData = function(sx, sy, sw, sh) {

--- a/builtin/jsb-adapter/HTMLCanvasElement.js
+++ b/builtin/jsb-adapter/HTMLCanvasElement.js
@@ -119,11 +119,11 @@ ctx2DProto.createImageData = function (args1, args2) {
 
 // void ctx.putImageData(imagedata, dx, dy);
 // void ctx.putImageData(imagedata, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight);
-ctx2DProto.putImageData = function (imagedata, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight) {
+ctx2DProto.putImageData = function (imageData, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight) {
     var height = imageData.height;
     var width = imageData.width;
     var imgBuffer = imageData.data;
-    var canvasWidth = this.canvas.width;
+    var canvasWidth = window.innerWidth;
     var canvasBuffer = this._canvas._data.data;
     dirtyX = dirtyX || 0;
     dirtyY = dirtyY || 0;
@@ -145,17 +145,17 @@ ctx2DProto.putImageData = function (imagedata, dx, dy, dirtyX, dirtyY, dirtyWidt
 
 // ImageData ctx.getImageData(sx, sy, sw, sh);
 ctx2DProto.getImageData = function (sx, sy, sw, sh) {
-    var canvasWidth = this.canvas.width;
+    var canvasWidth = window.innerWidth;
     var canvasBuffer = this._canvas._data.data;
     var imgBuffer = new Uint8ClampedArray(sw * sh * 4);
     for (var y = 0; y < sh; y++) {
         for (var x = 0; x < sw; x++) {
-            var canvasPos = (y + sh) * canvasWidth + (x + sw);
+            var canvasPos = (y + sy) * canvasWidth + (x + sx);
             var imgPos = y * sw + x;
-            imgBuffer[imgPos * 4 + 0] = canvasBuffer[imgPos * 4 + 0];
-            imgBuffer[imgPos * 4 + 1] = canvasBuffer[imgPos * 4 + 1];
-            imgBuffer[imgPos * 4 + 2] = canvasBuffer[imgPos * 4 + 2];
-            imgBuffer[imgPos * 4 + 3] = canvasBuffer[imgPos * 4 + 3];
+            imgBuffer[imgPos * 4 + 0] = canvasBuffer[canvasPos * 4 + 0];
+            imgBuffer[imgPos * 4 + 1] = canvasBuffer[canvasPos * 4 + 1];
+            imgBuffer[imgPos * 4 + 2] = canvasBuffer[canvasPos * 4 + 2];
+            imgBuffer[imgPos * 4 + 3] = canvasBuffer[canvasPos * 4 + 3];
         }
     }
     return new ImageData(imgBuffer);

--- a/builtin/jsb-adapter/HTMLCanvasElement.js
+++ b/builtin/jsb-adapter/HTMLCanvasElement.js
@@ -109,43 +109,56 @@ var ctx2DProto = CanvasRenderingContext2D.prototype;
 
 // ImageData ctx.createImageData(imagedata);
 // ImageData ctx.createImageData(width, height);
-ctx2DProto.createImageData = function(imagedata, width, height) {
-    if (typeof imagedata === 'number' && typeof width == 'number') {
-        return new ImageData(imagedata, width);
-    }
-    else if (imagedata instanceof ImageData) {
-        return new imageData(imagedata.data);
+ctx2DProto.createImageData = function (args1, args2) {
+    if (typeof args1 === 'number' && typeof args2 == 'number') {
+        return new ImageData(args1, args2);
+    } else if (args1 instanceof ImageData) {
+        return new imageData(args1.data);
     }
 }
 
 // void ctx.putImageData(imagedata, dx, dy);
 // void ctx.putImageData(imagedata, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight);
-ctx2DProto.putImageData = function(imagedata, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight) {
-    var desData = this._canvas._data;
-    var imgData = imageData.data;
+ctx2DProto.putImageData = function (imagedata, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight) {
     var height = imageData.height;
     var width = imageData.width;
+    var imgBuffer = imageData.data;
+    var canvasWidth = this.canvas.width;
+    var canvasBuffer = this._canvas._data.data;
     dirtyX = dirtyX || 0;
     dirtyY = dirtyY || 0;
-    dirtyWidth = dirtyWidth !== undefined? dirtyWidth: width;
-    dirtyHeight = dirtyHeight !== undefined? dirtyHeight: height;
+    dirtyWidth = dirtyWidth !== undefined ? dirtyWidth : width;
+    dirtyHeight = dirtyHeight !== undefined ? dirtyHeight : height;
     var limitBottom = dirtyY + dirtyHeight;
     var limitRight = dirtyX + dirtyWidth;
     for (var y = dirtyY; y < limitBottom; y++) {
-      for (var x = dirtyX; x < limitRight; x++) {
-        var imgPos = y * width + x;
-        var desPos = (y + dy) * this._canvas.width + (x + dx)
-        desData[desPos*4+0] = imgData[imgPos*4+0];
-        desData[desPos*4+1] = imgData[imgPos*4+1];
-        desData[desPos*4+2] = imgData[imgPos*4+2];
-        desData[desPos*4+3] = imgData[imgPos*4+3];
-      }
+        for (var x = dirtyX; x < limitRight; x++) {
+            var imgPos = y * width + x;
+            var canvasPos = (y + dy) * canvasWidth + (x + dx)
+            canvasBuffer[canvasPos * 4 + 0] = imgBuffer[imgPos * 4 + 0];
+            canvasBuffer[canvasPos * 4 + 1] = imgBuffer[imgPos * 4 + 1];
+            canvasBuffer[canvasPos * 4 + 2] = imgBuffer[imgPos * 4 + 2];
+            canvasBuffer[canvasPos * 4 + 3] = imgBuffer[imgPos * 4 + 3];
+        }
     }
 }
 
-ctx2DProto.getImageData = function(sx, sy, sw, sh) {
-    //REFINE:cjh
-    return this._canvas._data;
+// ImageData ctx.getImageData(sx, sy, sw, sh);
+ctx2DProto.getImageData = function (sx, sy, sw, sh) {
+    var canvasWidth = this.canvas.width;
+    var canvasBuffer = this._canvas._data.data;
+    var imgBuffer = new Uint8ClampedArray(sw * sh * 4);
+    for (var y = 0; y < sh; y++) {
+        for (var x = 0; x < sw; x++) {
+            var canvasPos = (y + sh) * canvasWidth + (x + sw);
+            var imgPos = y * sw + x;
+            imgBuffer[imgPos * 4 + 0] = canvasBuffer[imgPos * 4 + 0];
+            imgBuffer[imgPos * 4 + 1] = canvasBuffer[imgPos * 4 + 1];
+            imgBuffer[imgPos * 4 + 2] = canvasBuffer[imgPos * 4 + 2];
+            imgBuffer[imgPos * 4 + 3] = canvasBuffer[imgPos * 4 + 3];
+        }
+    }
+    return new ImageData(imgBuffer);
 }
 
 module.exports = HTMLCanvasElement;


### PR DESCRIPTION
通过修改 render_to_sprite 测试例，验证方法对 ImageData 的处理是否正确

- 代码
```JavaScript
saveImage () {
    if (CC_JSB) {
        // ... 以上部分代码未做修改
        let filePath = jsb.fileUtils.getWritablePath() + 'render_to_sprite_image.jpg';
        let ctx = window.__canvas.getContext('2d');
        ctx._width = width;
        ctx._height = height;
        let imageData = ctx.createImageData(width, height); // 初始化一个空的 ImageData
        imageData._data = data; // 将截图 texture 的像素数据，作为 imageData 的 data
        ctx.putImageData(imageData, width/4, height/2); // 将 ImageData 放到 ctx 中，指定偏移
        let imgToSave = ctx.getImageData(width/4 ,height/2, width/2, height/2);// 再从 ctx 中拿出 ImageData，指定偏移，区域大小
        let success = jsb.saveImageData(imgToSave.data, width/2, height/2, filePath); // 将从 ctx 中拿取到的ImageData ，保存成图片
       // ... 以下部分代码未做修改
```
- 截图

![render_to_sprite_image](https://user-images.githubusercontent.com/26329291/47284467-0ff4df00-d61a-11e8-8fce-71f033a55de2.jpg)
