### PR TITLE
flush commands more frequently( don't merge, just for testing)

### DIFF
--- a/builtin/glOptMode.js
+++ b/builtin/glOptMode.js
@@ -105,10 +105,11 @@ for (var k in gl) {
     _gl[k] = gl[k];
 }
 
-var total_size = 100000;
+var total_size = 5000;
 var next_index = 0;
 var buffer_data;
 var commandCount = 0;
+var max_command_count = 200;
 
 // Batch GL commands is enabled by default.
 function batchGLCommandsToNative() {
@@ -608,7 +609,9 @@ function disableVertexAttribArrayOpt(index) {
 
 function drawArraysOpt(mode, first, count) {
     // console.log('GLOpt: drawArrays');
-    if (next_index + 4 >= total_size) {
+    if (next_index + 4 >= total_size ||
+        commandCount >= max_command_count)
+    {
         flushCommands();
     }
     buffer_data[next_index] = GL_COMMAND_DRAW_ARRAYS;
@@ -621,7 +624,9 @@ function drawArraysOpt(mode, first, count) {
 
 function drawElementsOpt(mode, count, type, offset) {
     // console.log('GLOpt: drawElements');
-    if (next_index + 5 >= total_size) {
+    if (next_index + 5 >= total_size ||
+        commandCount >= max_command_count)
+    {
         flushCommands();
     }
     buffer_data[next_index] = GL_COMMAND_DRAW_ELEMENTS;


### PR DESCRIPTION
平衡 batch 与 GPU idle 的新的机制：

* 减小 buffer 的大小，可以及时 flush，同时减少传递的 buffer data
* 限制缓存的 gl 调用数量