### PR TITLE
convert safeArea return point to canvas pixels size

### DIFF
--- a/engine/jsb-sys.js
+++ b/engine/jsb-sys.js
@@ -46,6 +46,9 @@ sys.getSafeAreaRect = function() {
     var relatedPos = {left: 0, top: 0, width: screenSize.width, height: screenSize.height};
     cc.view.convertToLocationInView(leftBottom.x, leftBottom.y, relatedPos, leftBottom);
     cc.view.convertToLocationInView(rightTop.x, rightTop.y, relatedPos, rightTop);
+    // convert view point to design resolution size
+    cc.view._convertPointWithScale(leftBottom);
+    cc.view._convertPointWithScale(rightTop);
 
     return cc.rect(leftBottom.x, leftBottom.y, rightTop.x - leftBottom.x, rightTop.y - leftBottom.y);
 }


### PR DESCRIPTION
转换获取安全区域尺寸由视图尺寸大小转换为设计分辨率
link: https://github.com/cocos-creator/example-cases/pull/631 
相关场景修改
