### PR TITLE
Fix crash when some variable is not defined

### DIFF
--- a/engine/rt-game.js
+++ b/engine/rt-game.js
@@ -1,9 +1,5 @@
 cc.game.restart = function () {
-    if (typeof __restartVM != 'undefined') {
-        __restartVM();
-    } else {
-        console.error("The restartVM is not define!");
-    }
+    cc.sys.restartVM();
 };
 
 loadRuntime().onHide(function () {

--- a/engine/rt-game.js
+++ b/engine/rt-game.js
@@ -1,5 +1,9 @@
 cc.game.restart = function () {
-    __restartVM();
+    if (typeof __restartVM != 'undefined') {
+        __restartVM();
+    } else {
+        console.error("The restartVM is not define!");
+    }
 };
 
 loadRuntime().onHide(function () {

--- a/engine/rt-jsb.js
+++ b/engine/rt-jsb.js
@@ -81,9 +81,7 @@ if (typeof jsb.saveImageData === 'undefined') {
 
 if (typeof jsb.setPreferredFramesPerSecond === 'undefined'
     && typeof rt.setPreferredFramesPerSecond !== 'undefined') {
-    jsb.setPreferredFramesPerSecond = function (fps) {
-        rt.setPreferredFramesPerSecond(fps);
-    }
+    jsb.setPreferredFramesPerSecond = rt.setPreferredFramesPerSecond;
 } else {
     jsb.setPreferredFramesPerSecond = function () {
         console.error("The jsb.setPreferredFramesPerSecond is not define!");

--- a/engine/rt-jsb.js
+++ b/engine/rt-jsb.js
@@ -55,28 +55,37 @@ jsb.fileUtils = {
     },
 };
 
-jsb.saveImageData = function (data, width, height, filePath) {
-    var index = filePath.lastIndexOf(".");
-    if (index === -1) {
+if (typeof jsb.saveImageData === 'undefined') {
+    jsb.saveImageData = function (data, width, height, filePath) {
+        var index = filePath.lastIndexOf(".");
+        if (index === -1) {
+            return false;
+        }
+        var fileType = filePath.substr(index + 1);
+        var tempFilePath = rt.saveImageTempSync({
+            'data': data,
+            'width': width,
+            'height': height,
+            'fileType': fileType,
+        });
+        if (tempFilePath === '') {
+            return false;
+        }
+        var savedFilePath = rt.getFileSystemManager().saveFileSync(tempFilePath, filePath);
+        if (savedFilePath === filePath) {
+            return true;
+        }
         return false;
     }
-    var fileType = filePath.substr(index + 1);
-    var tempFilePath = rt.saveImageTempSync({
-        'data': data,
-        'width': width,
-        'height': height,
-        'fileType': fileType,
-    });
-    if (tempFilePath === '') {
-        return false;
-    }
-    var savedFilePath = rt.getFileSystemManager().saveFileSync(tempFilePath, filePath);
-    if (savedFilePath === filePath) {
-        return true;
-    }
-    return false;
 }
 
-jsb.setPreferredFramesPerSecond = function (fps) {
-    rt.setPreferredFramesPerSecond(fps);
+if (typeof jsb.setPreferredFramesPerSecond === 'undefined'
+    && typeof rt.setPreferredFramesPerSecond !== 'undefined') {
+    jsb.setPreferredFramesPerSecond = function (fps) {
+        rt.setPreferredFramesPerSecond(fps);
+    }
+} else {
+    jsb.setPreferredFramesPerSecond = function () {
+        console.error("The jsb.setPreferredFramesPerSecond is not define!");
+    }
 }

--- a/engine/rt-sys.js
+++ b/engine/rt-sys.js
@@ -27,8 +27,23 @@
 
 const sys = cc.sys;
 
-sys.getNetworkType = loadRuntime().getNetworkType;
-sys.getBatteryLevel = loadRuntime().getBatteryLevel;
-sys.garbageCollect = loadRuntime().triggerGC;
-sys.restartVM = __restartVM;
-sys.isObjectValid = __isObjectValid;
+if (typeof loadRuntime == 'function') {
+    var rt = loadRuntime();
+    sys.getNetworkType = rt.getNetworkType;
+    sys.getBatteryLevel = rt.getBatteryLevel;
+    sys.garbageCollect = rt.triggerGC;
+}
+if (typeof __restartVM !== 'undefined') {
+    sys.restartVM = __restartVM;
+} else {
+    sys.restartVM = function () {
+        console.error("The sys.restartVM is not define!");
+    }
+}
+if (typeof __isObjectValid !== 'undefined') {
+    sys.isObjectValid = __isObjectValid;
+} else {
+    sys.isObjectValid = function () {
+        console.error("The sys.isObjectValid is not define!");
+    }
+}

--- a/engine/rt-sys.js
+++ b/engine/rt-sys.js
@@ -27,7 +27,7 @@
 
 const sys = cc.sys;
 
-if (typeof loadRuntime == 'function') {
+if (typeof loadRuntime === 'function') {
     var rt = loadRuntime();
     sys.getNetworkType = rt.getNetworkType;
     sys.getBatteryLevel = rt.getBatteryLevel;
@@ -37,7 +37,7 @@ if (typeof __restartVM !== 'undefined') {
     sys.restartVM = __restartVM;
 } else {
     sys.restartVM = function () {
-        console.error("The sys.restartVM is not define!");
+        console.error("The restartVM is not define!");
     }
 }
 if (typeof __isObjectValid !== 'undefined') {


### PR DESCRIPTION
# 问题表现
如果 c++ 层没有定义 `__restartVM` 方法，在运行游戏时，会报错：

```
...

ERROR: Uncaught ReferenceError: __restartVM is not defined, location: 

...
```
现在需要支持及时在 c++ 不定义对应的方法，在适配层中也不报错。
