### PR TITLE
Fix error when file system throw error, fix CC_RUNTIME undiefined

### DIFF
--- a/builtin/jsb-adapter/HTMLCanvasElement.js
+++ b/builtin/jsb-adapter/HTMLCanvasElement.js
@@ -121,7 +121,7 @@ ctx2DProto.createImageData = function (args1, args2) {
 // void ctx.putImageData(imagedata, dx, dy);
 // void ctx.putImageData(imagedata, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight);
 ctx2DProto.putImageData = function (imageData, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight) {
-    if (CC_RUNTIME) {
+    if (typeof loadRuntime === "function") {
         var height = imageData.height;
         var width = imageData.width;
         var canvasWidth = this._canvas._width;

--- a/engine/jsb-loader.js
+++ b/engine/jsb-loader.js
@@ -80,7 +80,10 @@ if (CC_RUNTIME) {
     downloadText = function (item) {
         var url = item.url;
     
-        var result = loadRuntime().getFileSystemManager().readFileSync(url, "utf8");
+        var result = "";
+        try {
+            result = loadRuntime().getFileSystemManager().readFileSync(url, "utf8")
+        } catch (error) { }
         if (typeof result === 'string' && result) {
             return result;
         }
@@ -92,7 +95,10 @@ if (CC_RUNTIME) {
     downloadBinary = function (item) {
         var url = item.url;
     
-        var result = loadRuntime().getFileSystemManager().readFileSync(url);
+        var result = "";
+        try {
+            result = loadRuntime().getFileSystemManager().readFileSync(url);
+        } catch (error) { }
         if (result) {
             return result;
         }

--- a/engine/jsb-loader.js
+++ b/engine/jsb-loader.js
@@ -76,37 +76,31 @@ function _getFontFamily (fontHandle) {
 }
 
 let downloadBinary, downloadText, loadFont;
-if (CC_RUNTIME) {
-    downloadText = function (item) {
-        var url = item.url;
-    
-        var result = "";
-        try {
-            result = loadRuntime().getFileSystemManager().readFileSync(url, "utf8")
-        } catch (error) { }
-        if (typeof result === 'string' && result) {
-            return result;
-        }
-        else {
-            return new Error('Download text failed: ' + url);
-        }
-    };
-    
-    downloadBinary = function (item) {
-        var url = item.url;
-    
-        var result = "";
-        try {
-            result = loadRuntime().getFileSystemManager().readFileSync(url);
-        } catch (error) { }
-        if (result) {
-            return result;
-        }
-        else {
-            return new Error('Download binary file failed: ' + url);
-        }
-    };
+downloadText = function (item) {
+    var url = item.url;
 
+    var result = jsb.fileUtils.getStringFromFile(url);
+    if (typeof result === 'string' && result) {
+        return result;
+    }
+    else {
+        return new Error('Download text failed: ' + url);
+    }
+};
+
+downloadBinary = function (item) {
+    var url = item.url;
+
+    var result = jsb.fileUtils.getDataFromFile(url);
+    if (result) {
+        return result;
+    }
+    else {
+        return new Error('Download binary file failed: ' + url);
+    }
+};
+
+if (CC_RUNTIME) {
     loadFont = function (item) {
         let url = item.url;
         let fontFamilyName = _getFontFamily(url);
@@ -118,30 +112,6 @@ if (CC_RUNTIME) {
     };
 }
 else {
-    downloadText = function (item) {
-        var url = item.url;
-
-        var result = jsb.fileUtils.getStringFromFile(url);
-        if (typeof result === 'string' && result) {
-            return result;
-        }
-        else {
-            return new Error('Download text failed: ' + url);
-        }
-    };
-
-    downloadBinary = function (item) {
-        var url = item.url;
-
-        var result = jsb.fileUtils.getDataFromFile(url);
-        if (result) {
-            return result;
-        }
-        else {
-            return new Error('Download binary file failed: ' + url);
-        }
-    };
-
     loadFont = function (item, callback) {
         let url = item.url;
         let fontFamilyName = _getFontFamily(url);

--- a/engine/rt-jsb.js
+++ b/engine/rt-jsb.js
@@ -28,11 +28,19 @@
 var rt = loadRuntime();
 jsb.fileUtils = {
     getStringFromFile: function (url) {
-        return rt.getFileSystemManager().readFileSync(url, "utf8");
+        var result = "";
+        try {
+            result = rt.getFileSystemManager().readFileSync(url, "utf8");
+        } catch (error) { }
+        return result;
     },
 
     getDataFromFile: function (url) {
-        return rt.getFileSystemManager().readFileSync(url);
+        var result = "";
+        try {
+            result = rt.getFileSystemManager().readFileSync(url);
+        } catch (error) { }
+        return result;
     },
 
     getWritablePath: function () {
@@ -41,12 +49,20 @@ jsb.fileUtils = {
 
     writeToFile: function (map, url) {
         var str = JSON.stringify(map);
-        return rt.getFileSystemManager().writeFileSync(url, str, "utf8")
+        var result = false;
+        try {
+            rt.getFileSystemManager().writeFileSync(url, str, "utf8");
+            result = true;
+        } catch (error) { }
+        return result;
     },
 
     getValueMapFromFile: function (url) {
         var map_object = {};
-        var read = rt.getFileSystemManager().readFileSync(url, "utf8");
+        var read = "";
+        try {
+            read = rt.getFileSystemManager().readFileSync(url, "utf8");
+        } catch (error) { }
         if (!read) {
             return map_object;
         }

--- a/engine/rt-jsb.js
+++ b/engine/rt-jsb.js
@@ -28,7 +28,7 @@
 var rt = loadRuntime();
 jsb.fileUtils = {
     getStringFromFile: function (url) {
-        var result = "";
+        var result;
         try {
             result = rt.getFileSystemManager().readFileSync(url, "utf8");
         } catch (error) { }
@@ -36,7 +36,7 @@ jsb.fileUtils = {
     },
 
     getDataFromFile: function (url) {
-        var result = "";
+        var result;
         try {
             result = rt.getFileSystemManager().readFileSync(url);
         } catch (error) { }
@@ -59,7 +59,7 @@ jsb.fileUtils = {
 
     getValueMapFromFile: function (url) {
         var map_object = {};
-        var read = "";
+        var read;
         try {
             read = rt.getFileSystemManager().readFileSync(url, "utf8");
         } catch (error) { }


### PR DESCRIPTION
## 问题描述
1. 在 jsb-adapter/builtin 中，由于有可能出现运行的游戏为其他引擎的游戏，所以 CC_RUNTIME 有可能出现 undefined 的情况。
2. `loadRuntime().getFileSystemManager().readFileSync` 等同步方法，在出现错误时，修改为抛出异常，这样导致原有的代码可能报错，导致 JS 运行中断。

## 处理
1. 使用 `typeof loadRuntime === "function"` 来判断当前运行的平台。
2. 在使用到同步方法的地方，添加 try catch，来保证程序在处理文件报错后能够正常执行。
