### PR TITLE
show error when file operation fail

### DIFF
--- a/engine/rt-jsb.js
+++ b/engine/rt-jsb.js
@@ -31,7 +31,9 @@ jsb.fileUtils = {
         var result;
         try {
             result = rt.getFileSystemManager().readFileSync(url, "utf8");
-        } catch (error) { }
+        } catch (error) {
+            cc.error(error);
+        }
         return result;
     },
 
@@ -39,7 +41,9 @@ jsb.fileUtils = {
         var result;
         try {
             result = rt.getFileSystemManager().readFileSync(url);
-        } catch (error) { }
+        } catch (error) {
+            cc.error(error);
+        }
         return result;
     },
 
@@ -53,7 +57,9 @@ jsb.fileUtils = {
         try {
             rt.getFileSystemManager().writeFileSync(url, str, "utf8");
             result = true;
-        } catch (error) { }
+        } catch (error) {
+            cc.error(error);
+        }
         return result;
     },
 
@@ -62,7 +68,9 @@ jsb.fileUtils = {
         var read;
         try {
             read = rt.getFileSystemManager().readFileSync(url, "utf8");
-        } catch (error) { }
+        } catch (error) {
+            cc.error(error);
+        }
         if (!read) {
             return map_object;
         }


### PR DESCRIPTION
## 问题描述
@jareguo 提到不应该将错误隐藏起来，而应该将错误暴露给开发者，让开发者能够尽快解决问题，详情见 #74 。

## 解决
- 由于读取文件等接口，在许多 Creator 游戏中被调用，并且在开发过程中发现，开发者在调用这些接口时，经常出现 文件不存在、传递的路径不合法 的情况，如果直接中断游戏的正常运行的话，影响会比较大，所以不能直接中断游戏的运行。
- 现在对于出错的处理，在控制台中打印错误，而不是直接将所有错误都隐藏起来，导致开发者无法发现错误。
