### PR TITLE
fix setMusicVolume as 0

### DIFF
--- a/engine/jsb-audio.js
+++ b/engine/jsb-audio.js
@@ -32,7 +32,7 @@ cc.Audio = function (src) {
 };
 
 let handleVolume  = function (volume) {
-    if (!volume) {
+    if (volume === undefined) {
         // set default volume as 1
         volume = 1;
     }


### PR DESCRIPTION
changlog：
- 修复 2.0 原生平台，音量设置为0 时，变为 1 的bug

论坛反馈：
https://forum.cocos.com/t/2-1-0-bug/70203/3

关联：
https://github.com/cocos-creator/engine/pull/3625