### PR TITLE
optimized spine memory

### DIFF
--- a/engine/jsb-dragonbones.js
+++ b/engine/jsb-dragonbones.js
@@ -51,10 +51,10 @@
     // native factory
     //-------------------
 
-    var factoryProto = dragonBones.CCFactory.prototype;
+    let factoryProto = dragonBones.CCFactory.prototype;
     factoryProto.createArmatureNode = function (comp, armatureName, node) {
         node = node || new cc.Node();
-        var display = node.getComponent(dragonBones.ArmatureDisplay);
+        let display = node.getComponent(dragonBones.ArmatureDisplay);
         if (!display) {
             display = node.addComponent(dragonBones.ArmatureDisplay);
         }
@@ -72,7 +72,7 @@
     //-------------------
     // native armature
     //-------------------
-    var armatureProto = dragonBones.Armature.prototype;
+    let armatureProto = dragonBones.Armature.prototype;
     Object.defineProperty(armatureProto, 'animation', {
         get () {
             return this.getAnimation();
@@ -108,7 +108,7 @@
     //--------------------------
     // native CCArmatureDisplay
     //--------------------------
-    var nativeArmatureDisplayProto = dragonBones.CCArmatureDisplay.prototype;
+    let nativeArmatureDisplayProto = dragonBones.CCArmatureDisplay.prototype;
 
     Object.defineProperty(nativeArmatureDisplayProto,"node",{
         get : function () {
@@ -117,15 +117,15 @@
     });
 
     nativeArmatureDisplayProto.getRootNode = function () {
-        var rootDisplay = this.getRootDisplay();
+        let rootDisplay = this.getRootDisplay();
         return rootDisplay && rootDisplay._ccNode;
     };
 
     nativeArmatureDisplayProto.convertToWorldSpace = function (point) {
-        var newPos = this.convertToRootSpace(point);
-        var ccNode = this.getRootNode();
+        let newPos = this.convertToRootSpace(point);
+        let ccNode = this.getRootNode();
         if (!ccNode) return newPos;
-        var finalPos = ccNode.convertToWorldSpace(newPos);
+        let finalPos = ccNode.convertToWorldSpace(newPos);
         return finalPos;
     };
 
@@ -160,7 +160,7 @@
     //-------------------
     // native slot
     //-------------------
-    var slotProto = dragonBones.Slot.prototype;
+    let slotProto = dragonBones.Slot.prototype;
     Object.defineProperty(slotProto, 'childArmature', {
         get () {
             return this.getChildArmature();
@@ -185,7 +185,7 @@
     //------------------------
     // native TransformObject
     //------------------------
-    var transformObjectProto = dragonBones.TransformObject.prototype;
+    let transformObjectProto = dragonBones.TransformObject.prototype;
     Object.defineProperty(transformObjectProto, 'global', {
         get () {
             return this.getGlobal();
@@ -207,15 +207,15 @@
     ////////////////////////////////////////////////////////////
     // override DragonBonesAtlasAsset
     ////////////////////////////////////////////////////////////
-    var dbAtlas = dragonBones.DragonBonesAtlasAsset.prototype;
-    var gTextureIdx = 0;
-    var textureKeyMap = {};
-    var textureMap = new WeakMap();
-    var textureIdx2Name = {};
+    let dbAtlas = dragonBones.DragonBonesAtlasAsset.prototype;
+    let gTextureIdx = 0;
+    let textureKeyMap = {};
+    let textureMap = new WeakMap();
+    let textureIdx2Name = {};
 
     dbAtlas.recordTexture = function () {
         if (this._texture && this._oldTexture !== this._texture) {
-            var texKey = textureKeyMap[gTextureIdx] = {key:gTextureIdx};
+            let texKey = textureKeyMap[gTextureIdx] = {key:gTextureIdx};
             textureMap.set(texKey, this._texture);
             this._oldTexture = this._texture;
             this._texture.__textureIndex__ = gTextureIdx;
@@ -224,22 +224,22 @@
     };
 
     dbAtlas.getTextureByIndex = function (textureIdx) {
-        var texKey = textureKeyMap[textureIdx];
+        let texKey = textureKeyMap[textureIdx];
         if (!texKey) return;
         return textureMap.get(texKey);
     };
 
     dbAtlas.updateTextureAtlasData = function (factory) {
-        var url = this._texture.url;
-        var preAtlasInfo = textureIdx2Name[url];
-        var index;
+        let url = this._texture.url;
+        let preAtlasInfo = textureIdx2Name[url];
+        let index;
 
         // If the texture has store the atlas info before,then get native atlas object,and 
         // update script texture map.
         if (preAtlasInfo) {
             index = preAtlasInfo.index;
             this._textureAtlasData = factory.getTextureAtlasDataByIndex(preAtlasInfo.name,index);
-            var texKey = textureKeyMap[preAtlasInfo.index];
+            let texKey = textureKeyMap[preAtlasInfo.index];
             textureMap.set(texKey, this._texture);
             this._texture.__textureIndex__ = index;
             // If script has store the atlas info,but native has no atlas object,then
@@ -284,7 +284,7 @@
     ////////////////////////////////////////////////////////////
     // override DragonBonesAsset
     ////////////////////////////////////////////////////////////
-    var dbAsset = dragonBones.DragonBonesAsset.prototype;
+    let dbAsset = dragonBones.DragonBonesAsset.prototype;
 
     dbAsset.init = function (factory, atlasUUID) {
         this._factory = factory;
@@ -312,14 +312,14 @@
     ////////////////////////////////////////////////////////////
     // override ArmatureDisplay
     ////////////////////////////////////////////////////////////
-    var armatureDisplayProto = dragonBones.ArmatureDisplay.prototype;
-    var assembler = dragonBones.ArmatureDisplay._assembler;
-    var renderCompProto = cc.RenderComponent.prototype;
-    var RenderFlow = cc.RenderFlow;
-    var renderer = cc.renderer;
-    var renderEngine = renderer.renderEngine;
-    var gfx = renderEngine.gfx;
-    var VertexFormat = gfx.VertexFormat;
+    let armatureDisplayProto = dragonBones.ArmatureDisplay.prototype;
+    let assembler = dragonBones.ArmatureDisplay._assembler;
+    let renderCompProto = cc.RenderComponent.prototype;
+    let RenderFlow = cc.RenderFlow;
+    let renderer = cc.renderer;
+    let renderEngine = renderer.renderEngine;
+    let gfx = renderEngine.gfx;
+    let VertexFormat = gfx.VertexFormat;
 
     Object.defineProperty(armatureDisplayProto, 'armatureName', {
         get () {
@@ -327,7 +327,7 @@
         },
         set (value) {
             this._armatureName = value;
-            var animNames = this.getAnimationNames(this._armatureName);
+            let animNames = this.getAnimationNames(this._armatureName);
 
             if (!this.animationName || animNames.indexOf(this.animationName) < 0) {
                 this.animationName = '';
@@ -377,7 +377,7 @@
     });
 
     armatureDisplayProto._clearRenderData = function () {
-        this._materialData = undefined;
+        this._renderInfoOffset = undefined;
         this._nativeDisplay = undefined;
     };
 
@@ -409,7 +409,7 @@
         this._armature = this._nativeDisplay.armature();
         this._armature.animation.timeScale = this.timeScale;
         
-        this._materialData = this._nativeDisplay.getMaterialData();
+        this._renderInfoOffset = this._nativeDisplay.getRenderInfoOffset();
 
         if (this.animationName) {
             this.playAnimation(this.animationName, this.playTimes);
@@ -433,7 +433,7 @@
         }
     };
 
-    var _onLoad = armatureDisplayProto.onLoad;
+    let _onLoad = armatureDisplayProto.onLoad;
     armatureDisplayProto.onLoad = function () {
         if (_onLoad) {
             _onLoad.call(this);
@@ -463,7 +463,7 @@
         }
     };
 
-    var _onDestroy = armatureDisplayProto.onDestroy;
+    let _onDestroy = armatureDisplayProto.onDestroy;
     armatureDisplayProto.onDestroy = function(){
         _onDestroy.call(this);
         if (this._nativeDisplay) {
@@ -477,12 +477,12 @@
     ////////////////////////////////////////////////////////////
     // override webgl-assembler
     ////////////////////////////////////////////////////////////
-    var _slotColor = cc.color(0, 0, 255, 255);
-    var _boneColor = cc.color(255, 0, 0, 255);
-    var _originColor = cc.color(0, 255, 0, 255);
+    let _slotColor = cc.color(0, 0, 255, 255);
+    let _boneColor = cc.color(255, 0, 0, 255);
+    let _originColor = cc.color(0, 255, 0, 255);
 
-    var _getSlotMaterial = function (comp, tex, src, dst) {
-        var key = tex.url + src + dst;
+    let _getSlotMaterial = function (comp, tex, src, dst) {
+        let key = tex.url + src + dst;
         let baseMaterial = comp._material;
         if (!baseMaterial) return null;
 
@@ -491,7 +491,7 @@
         
         if (!material) {
 
-            var baseKey = baseMaterial._hash;
+            let baseKey = baseMaterial._hash;
             if (!materialCache[baseKey]) {
                 material = baseMaterial;
             } else {
@@ -504,7 +504,7 @@
             material.useColor = false;
 
             // update blend function
-            var pass = material._mainTech.passes[0];
+            let pass = material._mainTech.passes[0];
             pass.setBlend(
                 gfx.BLEND_FUNC_ADD,
                 src, dst,
@@ -534,14 +534,14 @@
 
     assembler.renderIA = function (comp, renderer) {
 
-        var nativeDisplay = comp._nativeDisplay;
+        let nativeDisplay = comp._nativeDisplay;
         if (!nativeDisplay) {
             return;
         }
 
-        var node = comp.node;
-        var iaPool = comp._iaPool;
-        var poolIdx = 0;
+        let node = comp.node;
+        let iaPool = comp._iaPool;
+        let poolIdx = 0;
 
         if (comp.__preColor__ === undefined || 
         !node.color.equals(comp.__preColor__)) {
@@ -549,26 +549,27 @@
             comp.__preColor__ = node.color;
         }
 
-        var materialData = comp._materialData;
+        let infoOffset = comp._renderInfoOffset[0];
+        let renderInfo = middleware.renderInfo;
 
-        var materialIdx = 0,realTextureIndex,realTexture;
-        var matLen = materialData[materialIdx++];
-        var indiceOffset = materialData[materialIdx++];
+        let materialIdx = 0,realTextureIndex,realTexture;
+        let matLen = renderInfo[infoOffset + materialIdx++];
         if (matLen == 0) return;
 
-        for (var index = 0; index < matLen; index++) {
-            realTextureIndex = materialData[materialIdx++];
+        for (let index = 0; index < matLen; index++) {
+            realTextureIndex = renderInfo[infoOffset + materialIdx++];
             realTexture = comp.dragonAtlasAsset.getTextureByIndex(realTextureIndex);
             
-            var material = _getSlotMaterial(comp, realTexture,
-                materialData[materialIdx++],
-                materialData[materialIdx++]);
+            let material = _getSlotMaterial(comp, realTexture,
+                renderInfo[infoOffset + materialIdx++],
+                renderInfo[infoOffset + materialIdx++]);
 
-            var glIB = materialData[materialIdx++];
-            var glVB = materialData[materialIdx++];
-            var segmentCount = materialData[materialIdx++];
+            let glIB = renderInfo[infoOffset + materialIdx++];
+            let glVB = renderInfo[infoOffset + materialIdx++];
+            let indiceOffset = renderInfo[infoOffset + materialIdx++];
+            let segmentCount = renderInfo[infoOffset + materialIdx++];
 
-            var ia = iaPool[poolIdx];
+            let ia = iaPool[poolIdx];
             if (!ia) {
                 ia = new middleware.MiddlewareIA();
                 iaPool[poolIdx] = ia;
@@ -579,7 +580,6 @@
             ia.setGLIBID(glIB);
             ia.setGLVBID(glVB);
 
-            indiceOffset += segmentCount;
             poolIdx++;
 
             comp._iaRenderData.ia = ia;
@@ -589,23 +589,23 @@
 
         if (comp.debugBones && comp._debugDraw) {
 
-            var graphics = comp._debugDraw;
+            let graphics = comp._debugDraw;
             graphics.clear();
 
             comp._debugData = comp._debugData || nativeDisplay.getDebugData();
-            var debugData = comp._debugData;
-            var debugIdx = 0;
+            let debugData = comp._debugData;
+            let debugIdx = 0;
 
             graphics.lineWidth = 5;
             graphics.strokeColor = _boneColor;
             graphics.fillColor = _slotColor; // Root bone color is same as slot color.
 
-            var debugBonesLen = debugData[debugIdx++];
-            for (var i = 0; i < debugBonesLen; i += 4) {
-                var bx = debugData[debugIdx++];
-                var by = debugData[debugIdx++];
-                var x = debugData[debugIdx++];
-                var y = debugData[debugIdx++];
+            let debugBonesLen = debugData[debugIdx++];
+            for (let i = 0; i < debugBonesLen; i += 4) {
+                let bx = debugData[debugIdx++];
+                let by = debugData[debugIdx++];
+                let x = debugData[debugIdx++];
+                let y = debugData[debugIdx++];
 
                 // Bone lengths.
                 graphics.moveTo(bx, by);

--- a/engine/jsb-dragonbones.js
+++ b/engine/jsb-dragonbones.js
@@ -26,6 +26,19 @@
     if (window.dragonBones === undefined || window.middleware === undefined) return;
     if (dragonBones.DragonBonesAtlasAsset === undefined) return;
 
+    // dragonbones global time scale.
+    Object.defineProperty(dragonBones, 'timeScale', {
+        get () {
+            return this._timeScale;
+        },
+        set (value) {
+            this._timeScale = value;
+            let factory = this.CCFactory.getInstance();
+            factory.setTimeScale(value);
+        },
+        configurable: true,
+    });
+
     ////////////////////////////////////////////////////////////
     // override dragonBones library by native dragonBones
     ////////////////////////////////////////////////////////////
@@ -550,7 +563,8 @@
         }
 
         let infoOffset = comp._renderInfoOffset[0];
-        let renderInfo = middleware.renderInfo;
+        let renderInfoMgr = middleware.renderInfoMgr;
+        let renderInfo = renderInfoMgr.renderInfo;
 
         let materialIdx = 0,realTextureIndex,realTexture;
         let matLen = renderInfo[infoOffset + materialIdx++];

--- a/engine/jsb-editor-support.js
+++ b/engine/jsb-editor-support.js
@@ -25,19 +25,19 @@
 (function(){
     if (window.middleware === undefined) return;
 
-    var renderEngine = cc.renderer.renderEngine;
-    var gfx = renderEngine.gfx;
+    let renderEngine = cc.renderer.renderEngine;
+    let gfx = renderEngine.gfx;
 
-    var middlewareMgr = middleware.MiddlewareManager.getInstance();
-    var director = cc.director;
+    let middlewareMgr = middleware.MiddlewareManager.getInstance();
+    let director = cc.director;
 
     director.on(cc.Director.EVENT_BEFORE_DRAW,function(){
         middlewareMgr.update(director._deltaTime);
     })
 
-    var MiddlewareIA = cc.Class({
+    let MiddlewareIA = cc.Class({
         ctor () {
-            var tempFormat = gfx.VertexFormat.XY_UV_Color;
+            let tempFormat = gfx.VertexFormat.XY_UV_Color;
             this._vertexBuffer = {
                 _format : tempFormat,
                 _usage : gfx.USAGE_DYNAMIC,
@@ -77,4 +77,13 @@
     });
 
     middleware.MiddlewareIA = MiddlewareIA;
+
+    let renderInfoMgr = middleware.RenderInfoMgr.getInstance();
+    middleware.renderInfoMgr = renderInfoMgr;
+    middleware.renderInfo = renderInfoMgr.getRenderInfo();
+    renderInfoMgr.__middleware__ = middleware;
+    renderInfoMgr.setResizeCallback(function() {
+        let middleware = this.__middleware__;
+        middleware.renderInfo = this.getRenderInfo();
+    });
 })();

--- a/engine/jsb-editor-support.js
+++ b/engine/jsb-editor-support.js
@@ -79,7 +79,7 @@
     middleware.MiddlewareIA = MiddlewareIA;
 
     let renderInfoMgr = middleware.RenderInfoMgr.getInstance();
-    middleware.renderInfoMgr = renderInfoMgr;
+    window.renderInfoMgr = renderInfoMgr;
     middleware.renderInfo = renderInfoMgr.getRenderInfo();
     renderInfoMgr.__middleware__ = middleware;
     renderInfoMgr.setResizeCallback(function() {

--- a/engine/jsb-editor-support.js
+++ b/engine/jsb-editor-support.js
@@ -79,11 +79,10 @@
     middleware.MiddlewareIA = MiddlewareIA;
 
     let renderInfoMgr = middleware.RenderInfoMgr.getInstance();
-    window.renderInfoMgr = renderInfoMgr;
-    middleware.renderInfo = renderInfoMgr.getRenderInfo();
+    middleware.renderInfoMgr = renderInfoMgr;
+    renderInfoMgr.renderInfo = renderInfoMgr.getRenderInfo();
     renderInfoMgr.__middleware__ = middleware;
     renderInfoMgr.setResizeCallback(function() {
-        let middleware = this.__middleware__;
-        middleware.renderInfo = this.getRenderInfo();
+        this.renderInfo = this.getRenderInfo();
     });
 })();

--- a/engine/jsb-spine-assembler.js
+++ b/engine/jsb-spine-assembler.js
@@ -25,21 +25,21 @@
 (function(){
     if (window.sp === undefined || window.spine === undefined || window.middleware === undefined) return;
 
-    var Skeleton = sp.Skeleton;
-    var renderer = cc.renderer;
-    var renderEngine = renderer.renderEngine;
-    var gfx = renderEngine.gfx;
-    var VertexFormat = gfx.VertexFormat;
-    var SpineMaterial = renderEngine.SpineMaterial;
-    var assembler = Skeleton._assembler;
+    let Skeleton = sp.Skeleton;
+    let renderer = cc.renderer;
+    let renderEngine = renderer.renderEngine;
+    let gfx = renderEngine.gfx;
+    let VertexFormat = gfx.VertexFormat;
+    let SpineMaterial = renderEngine.SpineMaterial;
+    let assembler = Skeleton._assembler;
     
-    var _slotColor = cc.color(0, 0, 255, 255);
-    var _boneColor = cc.color(255, 0, 0, 255);
-    var _originColor = cc.color(0, 255, 0, 255);
+    let _slotColor = cc.color(0, 0, 255, 255);
+    let _boneColor = cc.color(255, 0, 0, 255);
+    let _originColor = cc.color(0, 255, 0, 255);
     
-    var _getSlotMaterial = function (comp, tex, src, dst) {
+    let _getSlotMaterial = function (comp, tex, src, dst) {
     
-        var key = tex.url + src + dst;
+        let key = tex.url + src + dst;
 
         comp._material = comp._material || new SpineMaterial();
         let baseMaterial = comp._material;
@@ -48,7 +48,7 @@
 
         if (!material) {
 
-            var baseKey = baseMaterial._hash;
+            let baseKey = baseMaterial._hash;
             if (!materialCache[baseKey]) {
                 material = baseMaterial;
             } else {
@@ -61,7 +61,7 @@
             material.useTint = comp.useTint;
     
             // update blend function
-            var pass = material._mainTech.passes[0];
+            let pass = material._mainTech.passes[0];
             pass.setBlend(
                 gfx.BLEND_FUNC_ADD,
                 src, dst,
@@ -83,22 +83,22 @@
             material.updateHash(key);
         }
         return material;
-    }
+    };
     
     // native enable useModel
     assembler.useModel = true;
 
     assembler.genRenderDatas = function (comp, batchData) {
-    }
+    };
     
     assembler.updateRenderData = function (comp, batchData) {
-    }
+    };
     
     assembler.renderIA = function (comp, renderer) {
-        var nativeSkeleton = comp._skeleton;
+        let nativeSkeleton = comp._skeleton;
         if (!nativeSkeleton) return;
 
-        var node = comp.node;
+        let node = comp.node;
         if (!node) return;
 
         if (comp.__preColor__ === undefined || !node.color.equals(comp.__preColor__)) {
@@ -106,31 +106,32 @@
             comp.__preColor__ = node.color;
         }
 
-        var iaPool = comp._iaPool;
-        var poolIdx = 0;
+        let iaPool = comp._iaPool;
+        let poolIdx = 0;
 
-        var materialData = comp._materialData;
+        let infoOffset = comp._renderInfoOffset[0];
+        let renderInfo = middleware.renderInfo;
 
-        var materialIdx = 0,realTextureIndex,realTexture;
-        var matLen = materialData[materialIdx++];
-        var indiceOffset = materialData[materialIdx++];
-        var useTint = comp.useTint;
+        let materialIdx = 0,realTextureIndex,realTexture;
+        let matLen = renderInfo[infoOffset + materialIdx++];
+        let useTint = comp.useTint;
 
         if (matLen == 0) return;
 
-        for (var index = 0; index < matLen; index++) {
-            realTextureIndex = materialData[materialIdx++];
+        for (let index = 0; index < matLen; index++) {
+            realTextureIndex = renderInfo[infoOffset + materialIdx++];
             realTexture = comp.skeletonData.textures[realTextureIndex];
             
-            var material = _getSlotMaterial(comp, realTexture,
-                materialData[materialIdx++],
-                materialData[materialIdx++]);
+            let material = _getSlotMaterial(comp, realTexture,
+                renderInfo[infoOffset + materialIdx++],
+                renderInfo[infoOffset + materialIdx++]);
 
-            var glIB = materialData[materialIdx++];
-            var glVB = materialData[materialIdx++];
-            var segmentCount = materialData[materialIdx++];
+            let glIB = renderInfo[infoOffset + materialIdx++];
+            let glVB = renderInfo[infoOffset + materialIdx++];
+            let indiceOffset = renderInfo[infoOffset + materialIdx++];
+            let segmentCount = renderInfo[infoOffset + materialIdx++];
 
-            var ia = iaPool[poolIdx];
+            let ia = iaPool[poolIdx];
             if (!ia) {
                 ia = new middleware.MiddlewareIA();
                 iaPool[poolIdx] = ia;
@@ -141,7 +142,6 @@
             ia.setGLIBID(glIB);
             ia.setGLVBID(glVB);
 
-            indiceOffset += segmentCount;
             poolIdx ++;
 
             comp._iaRenderData.ia = ia;
@@ -151,20 +151,20 @@
     
         if ((comp.debugBones || comp.debugSlots) && comp._debugRenderer) {
     
-            var graphics = comp._debugRenderer;
+            let graphics = comp._debugRenderer;
             graphics.clear();
     
             comp._debugData = comp._debugData || nativeSkeleton.getDebugData();
-            var debugData = comp._debugData;
-            var debugIdx = 0;
+            let debugData = comp._debugData;
+            let debugIdx = 0;
     
             if (comp.debugSlots) {
                 // Debug Slot
                 graphics.strokeColor = _slotColor;
                 graphics.lineWidth = 5;
     
-                var debugSlotsLen = debugData[debugIdx++];
-                for(var i=0;i<debugSlotsLen;i+=8){
+                let debugSlotsLen = debugData[debugIdx++];
+                for(let i=0;i<debugSlotsLen;i+=8){
                     graphics.moveTo(debugData[debugIdx++], debugData[debugIdx++]);
                     graphics.lineTo(debugData[debugIdx++], debugData[debugIdx++]);
                     graphics.lineTo(debugData[debugIdx++], debugData[debugIdx++]);
@@ -180,12 +180,12 @@
                 graphics.strokeColor = _boneColor;
                 graphics.fillColor = _slotColor; // Root bone color is same as slot color.
     
-                var debugBonesLen = debugData[debugIdx++];
-                for (var i = 0; i < debugBonesLen; i += 4) {
-                    var bx = debugData[debugIdx++];
-                    var by = debugData[debugIdx++];
-                    var x = debugData[debugIdx++];
-                    var y = debugData[debugIdx++];
+                let debugBonesLen = debugData[debugIdx++];
+                for (let i = 0; i < debugBonesLen; i += 4) {
+                    let bx = debugData[debugIdx++];
+                    let by = debugData[debugIdx++];
+                    let x = debugData[debugIdx++];
+                    let y = debugData[debugIdx++];
     
                     // Bone lengths.
                     graphics.moveTo(bx, by);
@@ -201,6 +201,6 @@
                 }
             }
         }
-    }
+    };
 
 })();

--- a/engine/jsb-spine-assembler.js
+++ b/engine/jsb-spine-assembler.js
@@ -110,7 +110,8 @@
         let poolIdx = 0;
 
         let infoOffset = comp._renderInfoOffset[0];
-        let renderInfo = middleware.renderInfo;
+        let renderInfoMgr = middleware.renderInfoMgr;
+        let renderInfo = renderInfoMgr.renderInfo;
 
         let materialIdx = 0,realTextureIndex,realTexture;
         let matLen = renderInfo[infoOffset + materialIdx++];

--- a/engine/jsb-spine-skeleton.js
+++ b/engine/jsb-spine-skeleton.js
@@ -26,16 +26,61 @@
 (function(){
     if (window.sp === undefined || window.spine === undefined || window.middleware === undefined) return;
 
-    var RenderFlow = cc.RenderFlow;
-    var renderer = cc.renderer;
-    var renderEngine = renderer.renderEngine;
+    let skeletonDataProto = sp.SkeletonData.prototype;
+    skeletonDataProto.destroy = function () {
+        this._jsbTextures = null;
+        spine.disposeSkeletonData(this._uuid);
+        cc.Asset.prototype.destroy.call(this);
+    };
 
-    var animation = spine.SpineAnimation.prototype;
+    skeletonDataProto.init = function () {
+        if (this._inited) return;
+
+        let uuid = this._uuid;
+        if (!uuid) {
+            cc.errorID(7504);
+            return;
+        }
+        let jsonFile = cc.loader.md5Pipe ? cc.loader.md5Pipe.transformURL(this.nativeUrl, true) : this.nativeUrl;
+        let atlasText = this.atlasText;
+        if (!atlasText) {
+            cc.errorID(7508, this.name);
+            return;
+        }
+        let texValues = this.textures;
+        let texKeys = this.textureNames;
+        if (!(texValues && texValues.length > 0 && texKeys && texKeys.length > 0)) {
+            cc.errorID(7507, this.name);
+            return;
+        }
+        let jsbTextures = {};
+        for (let i = 0; i < texValues.length; ++i) {
+            let spTex = new middleware.Texture2D();
+            spTex.setRealTextureIndex(i);
+            spTex.setPixelsWide(texValues[i].width);
+            spTex.setPixelsHigh(texValues[i].height);
+            spTex.setTexParamCallback(function(texIdx,minFilter,magFilter,wrapS,warpT){
+                texValues[texIdx].setFilters(minFilter, magFilter);
+                texValues[texIdx].setWrapMode(wrapS, warpT);
+            }.bind(this));
+            jsbTextures[texKeys[i]] = spTex;
+        }
+        this._jsbTextures = jsbTextures;
+        spine.initSkeletonData(uuid, jsonFile, atlasText, jsbTextures, this.scale);
+
+        this._inited = true;
+    };
+
+    let RenderFlow = cc.RenderFlow;
+    let renderer = cc.renderer;
+    let renderEngine = renderer.renderEngine;
+
+    let animation = spine.SpineAnimation.prototype;
     // The methods are added to be compatibility with old versions.
     animation.setCompleteListener = function (listener) {
         this._compeleteListener = listener;
         this.setCompleteListenerNative(function (trackEntry) {
-            var loopCount = Math.floor(trackEntry.trackTime / trackEntry.animationEnd);
+            let loopCount = Math.floor(trackEntry.trackTime / trackEntry.animationEnd);
             this._compeleteListener(trackEntry, loopCount);
         });
     };
@@ -80,9 +125,9 @@
                 this._callback.call(this._target, this, trackEntry, sp.AnimationEventType.EVENT, event, 0);
             }
         });
-    }
+    };
 
-    var skeleton = sp.Skeleton.prototype;
+    let skeleton = sp.Skeleton.prototype;
     Object.defineProperty(skeleton, 'paused', {
         get () {
             return this._paused || false;
@@ -155,9 +200,9 @@
         set (value) {
             this._useTint = value;
             // Update cache material useTint property
-            var cache = this._materialCache;
-            for (var mKey in cache) {
-                var material = cache[mKey];
+            let cache = this._materialCache;
+            for (let mKey in cache) {
+                let material = cache[mKey];
                 if (material) {
                     material.useTint = this._useTint;
                 }
@@ -168,7 +213,7 @@
         }
     });
 
-    var _onLoad = skeleton.onLoad;
+    let _onLoad = skeleton.onLoad;
     skeleton.onLoad = function () {
         if (_onLoad) {
             _onLoad.call(this);
@@ -178,53 +223,28 @@
         this._iaPool.push(new middleware.MiddlewareIA());
 
         this._iaRenderData = new renderEngine.IARenderData();
-    }
+    };
 
     // Shield use batch in native
-    skeleton._updateBatch = function () {}
+    skeleton._updateBatch = function () {};
 
     skeleton.setSkeletonData = function (skeletonData) {
         null != skeletonData.width && null != skeletonData.height && this.node.setContentSize(skeletonData.width, skeletonData.height);
 
-        var uuid = skeletonData._uuid;
+        let uuid = skeletonData._uuid;
         if (!uuid) {
             cc.errorID(7504);
             return;
         }
-        var jsonFile = cc.loader.md5Pipe ? cc.loader.md5Pipe.transformURL(skeletonData.nativeUrl, true) : skeletonData.nativeUrl;
-        var atlasText = skeletonData.atlasText;
-        if (!atlasText) {
-            cc.errorID(7508, skeletonData.name);
-            return;
-        }
-        var texValues = skeletonData.textures;
-        var texKeys = skeletonData.textureNames;
-        if (!(texValues && texValues.length > 0 && texKeys && texKeys.length > 0)) {
-            cc.errorID(7507, skeletonData.name);
-            return;
-        }
-        var textures = {};
-        for (var i = 0; i < texValues.length; ++i) {
-            var spTex = new middleware.Texture2D();
-            spTex.setRealTextureIndex(i);
-            spTex.setPixelsWide(texValues[i].width);
-            spTex.setPixelsHigh(texValues[i].height);
-            spTex.setTexParamCallback(function(texIdx,minFilter,magFilter,wrapS,warpT){
-                texValues[texIdx].setFilters(minFilter, magFilter);
-                texValues[texIdx].setWrapMode(wrapS, warpT);
-            }.bind(this));
-            textures[texKeys[i]] = spTex;
-        }
 
-        var skeletonAni = new spine.SpineAnimation();
+        let skeletonAni = new spine.SpineAnimation();
         try {
-            spine._initSkeletonRenderer(skeletonAni, jsonFile, atlasText, textures, skeletonData.scale);
+            spine.initSkeletonRenderer(skeletonAni, uuid);
         } catch (e) {
             cc._throw(e);
             return;
         }
         this._skeleton = skeletonAni;
-        this._skeletonTextures = textures;
         this._skeleton._comp = this;
 
         this._skeleton.setOpacityModifyRGB(this.premultipliedAlpha);
@@ -233,7 +253,7 @@
         this._skeleton.setUseTint(this.useTint);
         this._skeleton.setTimeScale(this.timeScale);
 
-        this._materialData = this._skeleton.getMaterialData();
+        this._renderInfoOffset = this._skeleton.getRenderInfoOffset();
 
         // init skeleton listener
         this._startListener && this.setStartListener(this._startListener);
@@ -242,15 +262,15 @@
         this._eventListener && this.setEventListener(this._eventListener);
         this._interruptListener && this.setInterruptListener(this._interruptListener);
         this._disposeListener && this.setDisposeListener(this._disposeListener);
-    }
+    };
 
     skeleton.setAnimationStateData = function (stateData) {
         if (this._skeleton) {
             return this._skeleton.setAnimationStateData(stateData);
         }
-    }
+    };
 
-    var _onEnable = skeleton.onEnable;
+    let _onEnable = skeleton.onEnable;
     skeleton.onEnable = function () {
         _onEnable.call(this);
         if (this._skeleton) {
@@ -259,79 +279,79 @@
         this.node._renderFlag &= ~RenderFlow.FLAG_UPDATE_RENDER_DATA;
         this.node._renderFlag &= ~RenderFlow.FLAG_RENDER;
         this.node._renderFlag |= RenderFlow.FLAG_CUSTOM_IA_RENDER;
-    }
+    };
 
-    var _onDisable = skeleton.onDisable;
+    let _onDisable = skeleton.onDisable;
     skeleton.onDisable = function () {
         _onDisable.call(this);
         if (this._skeleton) {
             this._skeleton.onDisable();
         }
-    }
+    };
 
     skeleton.update = undefined;
 
     skeleton.updateWorldTransform = function () {
         this._skeleton && this._skeleton.updateWorldTransform();
-    }
+    };
 
     skeleton.setToSetupPose = function () {
         this._skeleton && this._skeleton.setToSetupPose();
-    }
+    };
 
     skeleton.setBonesToSetupPose = function () {
         this._skeleton && this._skeleton.setBonesToSetupPose();
-    }
+    };
 
     skeleton.setSlotsToSetupPose = function () {
         this._skeleton && this._skeleton.setSlotsToSetupPose();
-    }
+    };
 
     skeleton.setSlotsRange = function (startSlotIndex, endSlotIndex) {
         this._skeleton && this._skeleton.setSlotsRange(startSlotIndex, endSlotIndex);
-    }
+    };
 
     skeleton.findBone = function (boneName) {
         if (this._skeleton) return this._skeleton.findBone(boneName);
         return null;
-    }
+    };
 
     skeleton.findSlot = function (slotName) {
         if (this._skeleton) return this._skeleton.findSlot(slotName);
         return null;
-    }
+    };
 
     skeleton.setSkin = function (skinName) {
         if (this._skeleton) return this._skeleton.setSkin(skinName);
         return null;
-    }
+    };
 
     skeleton.getAttachment = function (slotName, attachmentName) {
         if (this._skeleton) return this._skeleton.getAttachment(slotName, attachmentName);
         return null;
-    }
+    };
 
     skeleton.setAttachment = function (slotName, attachmentName) {
         this._skeleton && this._skeleton.setAttachment(slotName, attachmentName);
-    }
+    };
 
     skeleton.getTextureAtlas = function (regionAttachment) {
         cc.warn("sp.Skeleton getTextureAtlas not support in native");
         return null;
-    }
+    };
 
     skeleton.setMix = function (fromAnimation, toAnimation, duration) {
         if (this._skeleton) {
             this._skeleton.setMix(fromAnimation, toAnimation, duration);
         }
-    }
+    };
 
     skeleton.setAnimation = function (trackIndex, name, loop) {
         if (this._skeleton) {
             return this._skeleton.setAnimation(trackIndex, name, loop);
         }
         return null;
-    }
+    };
 
     skeleton.addAnimation = function (trackIndex, name, loop, delay) {
         if (this._skeleton) {
@@ -339,138 +359,138 @@
             return this._skeleton.addAnimation(trackIndex, name, loop, delay);
         }
         return null;
-    }
+    };
 
     skeleton.findAnimation = function (name) {
         if (this._skeleton) return this._skeleton.findAnimation(name);
         return null;
-    }
+    };
 
     skeleton.getCurrent = function (trackIndex) {
         if (this._skeleton) {
             return this._skeleton.getCurrent(trackIndex);
         }
         return null;
-    }
+    };
 
     skeleton.clearTracks = function () {
         if (this._skeleton) {
             this._skeleton.clearTracks();
         }
-    }
+    };
 
     skeleton.clearTrack = function (trackIndex) {
         if (this._skeleton) {
             this._skeleton.clearTrack(trackIndex);
         }
-    }
+    };
 
     skeleton.setStartListener = function (listener) {
         this._startListener = listener;
         if (this._skeleton) {
             this._skeleton.setStartListener(listener);
         }
-    }
+    };
 
     skeleton.setInterruptListener = function (listener) {
         this._interruptListener = listener;
         if (this._skeleton) {
             this._skeleton.setInterruptListener(listener);
         }
-    }
+    };
 
     skeleton.setEndListener = function (listener) {
         this._endListener = listener;
         if (this._skeleton) {
             this._skeleton.setEndListener(listener);
         }
-    }
+    };
 
     skeleton.setDisposeListener = function (listener) {
         this._disposeListener = listener;
         if (this._skeleton) {
             this._skeleton.setDisposeListener(listener);
         }
-    }
+    };
 
     skeleton.setCompleteListener = function (listener) {
         this._completeListener = listener;
         if (this._skeleton) {
             this._skeleton.setCompleteListener(listener);
         }
-    }
+    };
 
     skeleton.setEventListener = function (listener) {
         this._eventListener = listener;
         if (this._skeleton) {
             this._skeleton.setEventListener(listener);
         }
-    }
+    };
 
     skeleton.setTrackStartListener = function (entry, listener) {
         if (this._skeleton) {
             this._skeleton.setTrackStartListener(entry, listener);
         }
-    }
+    };
 
     skeleton.setTrackInterruptListener = function (entry, listener) {
         if (this._skeleton) {
             this._skeleton.setTrackInterruptListener(entry, listener);
         }
-    }
+    };
 
     skeleton.setTrackEndListener = function (entry, listener) {
         if (this._skeleton) {
             this._skeleton.setTrackEndListener(entry, listener);
         }
-    }
+    };
 
     skeleton.setTrackDisposeListener = function (entry, listener) {
         if (this._skeleton) {
             this._skeleton.setTrackDisposeListener(entry, listener);
         }
-    }
+    };
 
     skeleton.setTrackCompleteListener = function (entry, listener) {
         if (this._skeleton) {
             this._skeleton.setTrackCompleteListener(entry, listener);
         }
-    }
+    };
 
     skeleton.setTrackEventListener = function (entry, listener) {
         if (this._skeleton) {
             this._skeleton.setTrackEventListener(entry, listener);
         }
-    }
+    };
 
     skeleton.getState = function () {
         if (this._skeleton) {
             return this._skeleton.getState();
         }
-    }
+    };
 
     skeleton._ensureListener = function () {
         cc.warn("sp.Skeleton _ensureListener not need in native");
-    }
+    };
 
     skeleton._updateSkeletonData = function () {
         if (this.skeletonData) {
+            this.skeletonData.init();
             this.setSkeletonData(this.skeletonData);
             this.defaultSkin && this._skeleton.setSkin(this.defaultSkin);
             this.animation = this.defaultAnimation;
         }
-    }
+    };
 
-    var _onDestroy = skeleton.onDestroy;
+    let _onDestroy = skeleton.onDestroy;
     skeleton.onDestroy = function(){
         _onDestroy.call(this);
-        this._skeletonTextures = undefined;
         if (this._skeleton) {
             this._skeleton.stopSchedule();
             this._skeleton._comp = undefined;
             this._skeleton = undefined;
         }
         this._materialCache = undefined;
-    }
+    };
 
 })();

--- a/engine/jsb-spine-skeleton.js
+++ b/engine/jsb-spine-skeleton.js
@@ -26,6 +26,18 @@
 (function(){
     if (window.sp === undefined || window.spine === undefined || window.middleware === undefined) return;
 
+    // spine global time scale
+    Object.defineProperty(sp, 'timeScale', {
+        get () {
+            return this._timeScale;
+        },
+        set (value) {
+            this._timeScale = value;
+            spine.SpineAnimation.setGlobalTimeScale(value);
+        },
+        configurable: true,
+    });
+
     let skeletonDataProto = sp.SkeletonData.prototype;
     skeletonDataProto.destroy = function () {
         this._jsbTextures = null;

--- a/engine/jsb-spine-skeleton.js
+++ b/engine/jsb-spine-skeleton.js
@@ -41,7 +41,6 @@
             cc.errorID(7504);
             return;
         }
-        let jsonFile = cc.loader.md5Pipe ? cc.loader.md5Pipe.transformURL(this.nativeUrl, true) : this.nativeUrl;
         let atlasText = this.atlasText;
         if (!atlasText) {
             cc.errorID(7508, this.name);
@@ -66,7 +65,7 @@
             jsbTextures[texKeys[i]] = spTex;
         }
         this._jsbTextures = jsbTextures;
-        spine.initSkeletonData(uuid, jsonFile, atlasText, jsbTextures, this.scale);
+        spine.initSkeletonData(uuid, this.skeletonJsonStr, atlasText, jsbTextures, this.scale);
 
         this._inited = true;
     };


### PR DESCRIPTION
关联pr：
cocos2d-x-lite:https://github.com/cocos-creator/cocos2d-x-lite/pull/1694
engine:https://github.com/cocos-creator/engine/pull/3999
1 相同骨骼共享SkeletonData，节省内存的同时，加快相同骨骼动画的加载
2 使用全局TypedArray 代替 每个骨骼对象独有TypedArray，每个骨骼对象只需记录全局TypedArray的偏移位置即可，减少内存碎片，且可简化逻辑。
3 添加spine 和 dragonbones 全局timeScale字段，通过sp.timeScale 和 dragonBones.timeScale 设置。