### PR TITLE
refine spine and dragonbones

### DIFF
--- a/engine/jsb-dragonbones.js
+++ b/engine/jsb-dragonbones.js
@@ -83,6 +83,17 @@
     };
 
     //-------------------
+    // native animation state
+    //-------------------
+    let animationStateProto = dragonBones.AnimationState.prototype;
+    let _isPlaying = animationStateProto.isPlaying;
+    Object.defineProperty(animationStateProto, 'isPlaying', {
+        get () {
+            return _isPlaying.call(this);
+        }
+    });
+
+    //-------------------
     // native armature
     //-------------------
     let armatureProto = dragonBones.Armature.prototype;
@@ -221,30 +232,44 @@
     // override DragonBonesAtlasAsset
     ////////////////////////////////////////////////////////////
     let dbAtlas = dragonBones.DragonBonesAtlasAsset.prototype;
-    let gTextureIdx = 0;
-    let textureKeyMap = {};
-    let textureMap = new WeakMap();
-    let textureIdx2Name = {};
+    let _gTextureIdx = 1;
+    let _textureKeyMap = {};
+    let _textureMap = new WeakMap();
+    let _textureIdx2Name = {};
+
+    dbAtlas.removeRecordTexture = function (texture) {
+        if (!texture) return;
+        delete _textureIdx2Name[texture.url];
+        let index = texture.__textureIndex__;
+        if (index) {
+            let texKey = _textureKeyMap[index];
+            if (texKey && _textureMap.has(texKey)) {
+                _textureMap.delete(texKey);
+                delete _textureKeyMap[index];
+            }
+        }
+    };
 
     dbAtlas.recordTexture = function () {
         if (this._texture && this._oldTexture !== this._texture) {
-            let texKey = textureKeyMap[gTextureIdx] = {key:gTextureIdx};
-            textureMap.set(texKey, this._texture);
+            this.removeRecordTexture(this._oldTexture);
+            let texKey = _textureKeyMap[_gTextureIdx] = {key:_gTextureIdx};
+            _textureMap.set(texKey, this._texture);
             this._oldTexture = this._texture;
-            this._texture.__textureIndex__ = gTextureIdx;
-            gTextureIdx++;
+            this._texture.__textureIndex__ = _gTextureIdx;
+            _gTextureIdx++;
         }
     };
 
     dbAtlas.getTextureByIndex = function (textureIdx) {
-        let texKey = textureKeyMap[textureIdx];
+        let texKey = _textureKeyMap[textureIdx];
         if (!texKey) return;
-        return textureMap.get(texKey);
+        return _textureMap.get(texKey);
     };
 
     dbAtlas.updateTextureAtlasData = function (factory) {
         let url = this._texture.url;
-        let preAtlasInfo = textureIdx2Name[url];
+        let preAtlasInfo = _textureIdx2Name[url];
         let index;
 
         // If the texture has store the atlas info before,then get native atlas object,and 
@@ -252,8 +277,8 @@
         if (preAtlasInfo) {
             index = preAtlasInfo.index;
             this._textureAtlasData = factory.getTextureAtlasDataByIndex(preAtlasInfo.name,index);
-            let texKey = textureKeyMap[preAtlasInfo.index];
-            textureMap.set(texKey, this._texture);
+            let texKey = _textureKeyMap[preAtlasInfo.index];
+            _textureMap.set(texKey, this._texture);
             this._texture.__textureIndex__ = index;
             // If script has store the atlas info,but native has no atlas object,then
             // still new native texture2d object,but no call recordTexture to increase
@@ -272,7 +297,7 @@
         this.jsbTexture.setPixelsHigh(this._texture.height);
         this._textureAtlasData = factory.parseTextureAtlasData(this.atlasJson, this.jsbTexture, this._uuid);
 
-        textureIdx2Name[url] = {name:this._textureAtlasData.name,index:index};
+        _textureIdx2Name[url] = {name:this._textureAtlasData.name, index:index};
     };
 
     dbAtlas.init = function (factory) {
@@ -292,13 +317,21 @@
         }
     };
 
-    dbAtlas._clear = function () {
+    dbAtlas._clear = function (dontRecordTexture) {
         if (this._factory) {
             this._factory.removeTextureAtlasData(this._uuid, true);
             this._factory.removeDragonBonesDataByUUID(this._uuid, true);
         }
         this._textureAtlasData = null;
-        this.recordTexture();
+        if (!dontRecordTexture) {
+            this.recordTexture();
+        }
+    };
+
+    dbAtlas.destroy = function () {
+        this.removeRecordTexture(this._texture);
+        this._clear(false);
+        cc.Asset.prototype.destroy.call(this);
     };
 
     ////////////////////////////////////////////////////////////
@@ -454,6 +487,7 @@
         this._armature.animation.timeScale = this.timeScale;
         
         this._renderInfoOffset = this._nativeDisplay.getRenderInfoOffset();
+        this._renderInfoOffset[0] = 0;
 
         if (this.animationName) {
             this.playAnimation(this.animationName, this.playTimes);
@@ -470,7 +504,7 @@
         // Get material
         let material = this.sharedMaterials[0];
         if (!material) {
-            material = cc.Material.getInstantiatedBuiltinMaterial('sprite', this);
+            material = cc.Material.getInstantiatedBuiltinMaterial('2d-sprite', this);
             material.define('_USE_MODEL', true);
             material.define('USE_TEXTURE', true);
         } else {
@@ -491,6 +525,9 @@
             this._factory.add(this._armature);
         }
         this._activateMaterial();
+        if (this._renderInfoOffset) {
+            this._renderInfoOffset[0] = 0;
+        }
     };
 
     armatureDisplayProto.onDisable = function () {
@@ -618,6 +655,8 @@
         }
 
         let infoOffset = renderInfoOffset[0];
+        renderInfoOffset[0] = 0;
+
         let renderInfoMgr = middleware.renderInfoMgr;
         let renderInfo = renderInfoMgr.renderInfo;
 

--- a/engine/jsb-dragonbones.js
+++ b/engine/jsb-dragonbones.js
@@ -206,6 +206,12 @@
         }
     });
 
+    Object.defineProperty(slotProto, 'parent', {
+        get () {
+            return this.getParent();
+        }
+    });
+
     //------------------------
     // native TransformObject
     //------------------------
@@ -505,12 +511,12 @@
         let material = this.sharedMaterials[0];
         if (!material) {
             material = cc.Material.getInstantiatedBuiltinMaterial('2d-sprite', this);
-            material.define('_USE_MODEL', true);
-            material.define('USE_TEXTURE', true);
         } else {
             material = cc.Material.getInstantiatedMaterial(material, this);
         }
 
+        material.define('_USE_MODEL', true);
+        material.define('USE_TEXTURE', true);
         material.setProperty('texture', texture);
         this.sharedMaterials[0] = material;
 

--- a/engine/jsb-spine-assembler.js
+++ b/engine/jsb-spine-assembler.js
@@ -100,6 +100,8 @@
         let poolIdx = 0;
 
         let infoOffset = renderInfoOffset[0];
+        renderInfoOffset[0] = 0;
+        
         let renderInfoMgr = middleware.renderInfoMgr;
         let renderInfo = renderInfoMgr.renderInfo;
 
@@ -115,7 +117,7 @@
 
         for (let index = 0; index < matLen; index++) {
             realTextureIndex = renderInfo[infoOffset + materialIdx++];
-            realTexture = comp.skeletonData.textures[realTextureIndex];
+            realTexture = comp.skeletonData.getTextureByIndex(realTextureIndex);
             if (!realTexture) return;
 
             let material = _getSlotMaterial(comp, realTexture,

--- a/engine/jsb-spine-skeleton.js
+++ b/engine/jsb-spine-skeleton.js
@@ -333,12 +333,12 @@
         let material = this.sharedMaterials[0];
         if (!material) {
             material = cc.Material.getInstantiatedBuiltinMaterial('2d-spine', this);
-            material.define('_USE_MODEL', true);
         }
         else {
             material = cc.Material.getInstantiatedMaterial(material, this);
         }
 
+        material.define('_USE_MODEL', true);
         this.sharedMaterials[0] = material;
 
         this.markForUpdateRenderData(false);

--- a/engine/jsb-spine-skeleton.js
+++ b/engine/jsb-spine-skeleton.js
@@ -39,9 +39,27 @@
     });
 
     let skeletonDataProto = sp.SkeletonData.prototype;
+    let _gTextureIdx = 1;
+    let _textureKeyMap = {};
+    let _textureMap = new WeakMap();
+
     skeletonDataProto.destroy = function () {
-        this._jsbTextures = null;
-        spine.disposeSkeletonData(this._uuid);
+        if (this._jsbTextures) {
+            this._jsbTextures = null;
+            spine.disposeSkeletonData(this._uuid);
+            let textures = this.textures;
+            for (let i = 0; i < textures.length; ++i) {
+                let texture = textures[i];
+                let index = texture && texture.__textureIndex__; 
+                if (index) {
+                    let texKey = _textureKeyMap[index];
+                    if (texKey && _textureMap.has(texKey)) {
+                        _textureMap.delete(texKey);
+                        delete _textureKeyMap[index];
+                    }
+                }
+            }
+        }
         cc.Asset.prototype.destroy.call(this);
     };
 
@@ -58,28 +76,47 @@
             cc.errorID(7508, this.name);
             return;
         }
-        let texValues = this.textures;
-        let texKeys = this.textureNames;
-        if (!(texValues && texValues.length > 0 && texKeys && texKeys.length > 0)) {
+        let textures = this.textures;
+        let textureNames = this.textureNames;
+        if (!(textures && textures.length > 0 && textureNames && textureNames.length > 0)) {
             cc.errorID(7507, this.name);
             return;
         }
+
         let jsbTextures = {};
-        for (let i = 0; i < texValues.length; ++i) {
+        for (let i = 0; i < textures.length; ++i) {
+            let texture = textures[i];
+            let textureIdx = this.recordTexture(texture);
             let spTex = new middleware.Texture2D();
-            spTex.setRealTextureIndex(i);
-            spTex.setPixelsWide(texValues[i].width);
-            spTex.setPixelsHigh(texValues[i].height);
+            spTex.setRealTextureIndex(textureIdx);
+            spTex.setPixelsWide(texture.width);
+            spTex.setPixelsHigh(texture.height);
             spTex.setTexParamCallback(function(texIdx,minFilter,magFilter,wrapS,warpT){
-                texValues[texIdx].setFilters(minFilter, magFilter);
-                texValues[texIdx].setWrapMode(wrapS, warpT);
+                let tex = this.getTextureByIndex(texIdx);
+                tex.setFilters(minFilter, magFilter);
+                tex.setWrapMode(wrapS, warpT);
             }.bind(this));
-            jsbTextures[texKeys[i]] = spTex;
+            jsbTextures[textureNames[i]] = spTex;
         }
         this._jsbTextures = jsbTextures;
         spine.initSkeletonData(uuid, this.skeletonJsonStr, atlasText, jsbTextures, this.scale);
 
         this._inited = true;
+    };
+
+    skeletonDataProto.recordTexture = function (texture) {
+        let index = _gTextureIdx;
+        let texKey = _textureKeyMap[index] = {key:index};
+        texture.__textureIndex__ = index;
+        _textureMap.set(texKey, texture);
+        _gTextureIdx++;
+        return index;
+    };
+
+    skeletonDataProto.getTextureByIndex = function (textureIdx) {
+        let texKey = _textureKeyMap[textureIdx];
+        if (!texKey) return;
+        return _textureMap.get(texKey);
     };
 
     let RenderFlow = cc.RenderFlow;
@@ -275,6 +312,7 @@
         this._skeleton.setTimeScale(this.timeScale);
 
         this._renderInfoOffset = this._skeleton.getRenderInfoOffset();
+        this._renderInfoOffset[0] = 0;
 
         // init skeleton listener
         this._startListener && this.setStartListener(this._startListener);
@@ -294,7 +332,7 @@
     skeleton._activateMaterial = function () {
         let material = this.sharedMaterials[0];
         if (!material) {
-            material = cc.Material.getInstantiatedBuiltinMaterial('spine', this);
+            material = cc.Material.getInstantiatedBuiltinMaterial('2d-spine', this);
             material.define('_USE_MODEL', true);
         }
         else {
@@ -314,6 +352,9 @@
             this._skeleton.onEnable();
         }
         this._activateMaterial();
+        if (this._renderInfoOffset) {
+            this._renderInfoOffset[0] = 0;
+        }
     };
 
     skeleton.onDisable = function () {


### PR DESCRIPTION
修复原生spine偶尔第一帧贴图不正确的问题
当spine资源销毁时，释放无用缓存数据
当dragonbones资源销毁时，释放无用缓存数据
原生dragonbones AnimationState 添加isPlaying方法