### PR TITLE
fix audioEngine restore paused audio on show event

### DIFF
--- a/engine/jsb-audio.js
+++ b/engine/jsb-audio.js
@@ -253,9 +253,9 @@ let handleVolume  = function (volume) {
         }
     };
 
-    // incompatible implementation for game pause & resume
-    audioEngine._break = audioEngine.pauseAll;
-    audioEngine._restore = audioEngine.resumeAll;
+    // Unnecessary on native platform
+    audioEngine._break = function () {};
+    audioEngine._restore = function () {};
 
     // deprecated
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1356

changeLog:
- 修复原生平台，暂停音乐后，从后台切回前台，还会继续播放的 bug



底层自动做了处理，这里不需要再另外适配 _restore 和 _break，用空实现就好了