### PR TITLE
CHERRY-PICK: fix audioEngine restore paused audio on show event

### DIFF
--- a/engine/jsb-audio.js
+++ b/engine/jsb-audio.js
@@ -253,9 +253,9 @@ let handleVolume  = function (volume) {
         }
     };
 
-    // incompatible implementation for game pause & resume
-    audioEngine._break = audioEngine.pauseAll;
-    audioEngine._restore = audioEngine.resumeAll;
+    // Unnecessary on native platform
+    audioEngine._break = function () {};
+    audioEngine._restore = function () {};
 
     // deprecated
 


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/123

从 2.2 分支的修复迁移过来
https://github.com/cocos-creator-packages/jsb-adapter/pull/141

changeLog: 
- 修复原生屏态从后台切前台会自动播发已暂停音频的问题