### PR TITLE
hide or show editbox labels on Mac or Win platform

### DIFF
--- a/engine/jsb-editbox.js
+++ b/engine/jsb-editbox.js
@@ -133,6 +133,9 @@
             jsb.inputBox.onConfirm(onConfirm);
             jsb.inputBox.onComplete(onComplete);
 
+            if (!cc.sys.isMobile) {
+                this._delegate._hideLabels();
+            }
             jsb.inputBox.show({
                 defaultValue: delegate._string,
                 maxLength: delegate.maxLength,
@@ -151,6 +154,9 @@
 
         endEditing () {
             this._editing = false;
+            if (!cc.sys.isMobile) {
+                this._delegate._showLabels();
+            }
             jsb.inputBox.hide();
             this._delegate.editBoxEditingDidEnded();
         },


### PR DESCRIPTION
changeLog:
- 修复 Mac 和 Win32 平台下，editBox 输入状态下，字符重叠问题