### PR TITLE
fix editbox input postion for canvas SHOW_ALL fit mode

### DIFF
--- a/engine/jsb-editbox.js
+++ b/engine/jsb-editbox.js
@@ -183,9 +183,10 @@
             let finalScaleX = matrix.m00 * scaleX;
             let finaleScaleY = matrix.m05 * scaleY;
 
+            let viewportRect = cc.view._viewportRect;
             return {
-                x: matrix.m12 * finalScaleX,
-                y: matrix.m13 * finaleScaleY,
+                x: matrix.m12 * finalScaleX + viewportRect.x,
+                y: matrix.m13 * finaleScaleY + viewportRect.y,
                 width: contentSize.width * finalScaleX,
                 height: contentSize.height * finaleScaleY
             };


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1788

changeLog:
- 修复模拟器在 canvas SHOW_ALL 适配模式下，editBox 输入框位置不正确的问题