### PR TITLE
BUG FIX:EditBox在删除所有字符之后，再次点击无法弹出键盘

### DIFF
--- a/builtin/jsb_input.js
+++ b/builtin/jsb_input.js
@@ -92,6 +92,7 @@ jsb.inputBox = {
      * Values of options.inputType can be [text|email|number|phone|password].
      */
 	show: function(options) {
+		options.defaultValue = options.defaultValue ? "" + options.defaultValue : "";
 		jsb.showInputBox(options);
 	},
 	hide: function() {


### PR DESCRIPTION
问题：EditBox在删除所有字符之后，再次点击无法弹出键盘，
log：
2019-09-23 17:33:46.054 18848-18908/? E/jswrapper: jsb: ERROR: File F:/Patti/PattiSvn/build/jsb-default/frameworks/cocos2d-x/cocos/scripting/js-bindings/manual/jsb_global.cpp: Line: 1204, Function: JSB_showInputBox
2019-09-23 17:33:46.054 18848-18908/? E/jswrapper: defaultValue is invalid!
2019-09-23 17:33:46.054 18848-18908/? E/jswrapper: [ERROR] Failed to invoke JSB_showInputBox, location: F:/Patti/PattiSvn/build/jsb-default/frameworks/cocos2d-x/cocos/scripting/js-bindings/manual/jsb_global.cpp:1275

Android 8.0 huawei nova 3e 机器上，Editbox的默认值设置为空，格式为数字，
1、在EditBox上输入数字，
2、关闭键盘，
3、再次点击EditBox，键盘弹不出来。

以上修改只能保证可以弹出键盘，但是EditBox在删除所有字符之后，会显示NAN。java估计也要修改。
