### PR TITLE
Fix a problem that the color of the render component was not updated on native.

### DIFF
--- a/engine/scene/render-flow.js
+++ b/engine/scene/render-flow.js
@@ -54,7 +54,7 @@ RenderFlow.render = function (scene) {
         }
         if (flag & RenderFlow.FLAG_COLOR) {
             node._dirtyPtr[0] &= ~RenderFlow.FLAG_COLOR;
-            assembler.updateColor && assembler.updateColor(comp);
+            comp._updateColor && comp._updateColor();
         }
 
     }


### PR DESCRIPTION
修改说明：
修复原生平台Label更新节点颜色无效的问题。

反馈自论坛：https://forum.cocos.com/t/cocos-creator-v2-2-0-09-30-beta-3/82831/404?u=cary