### PR TITLE
Motion streak module exclude issue

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -78,7 +78,7 @@
   },
   {
     "name": "MotionStreak",
-    "entries": [],
+    "entries": ["./engine/assemblers/motion-streak.js"],
     "dependencies": ["WebGL Renderer"]
   },
   {


### PR DESCRIPTION
修复 原生平台剔除motion streak模块会报错的问题