### PR TITLE
Fix a problem that graphic drawing content is reset on native platform.

### DIFF
--- a/engine/assemblers/graphics-assembler.js
+++ b/engine/assemblers/graphics-assembler.js
@@ -7,10 +7,15 @@ proto.init = function (renderComp) {
     this.ignoreOpacityFlag();
 }
 
-let _genBuffer = proto.genBuffer;
 proto.genBuffer = function (graphics, cverts) {
-    let buffer = _genBuffer.call(this, graphics, cverts);
-    buffer.meshbuffer.setNativeAssembler(this);
+    let buffers = this.getBuffers(); 
+    let buffer = buffers[this._bufferOffset];
+    let meshbuffer = buffer.meshbuffer;
+
+    meshbuffer.requestStatic(cverts, cverts*3);
+    this._buffer = buffer;
+
+    meshbuffer.setNativeAssembler(this);
     return buffer;
 }
 


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2052

修改说明：
Web平台会重新创建MeshBuffer来进行新的内容绘制，原生平台不需要重新创建，使用同一个buffer的RenderDataList进行更新。