### PR TITLE
Optimize Dragonbones and Spine color update

### DIFF
--- a/engine/jsb-dragonbones.js
+++ b/engine/jsb-dragonbones.js
@@ -465,6 +465,8 @@
         this._nativeDisplay.bindNodeProxy(this.node._proxy);
         this._nativeDisplay.setOpacityModifyRGB(this.premultipliedAlpha);
         this._nativeDisplay.setBatchEnabled(this.enableBatch);
+        this._nativeDisplay.setColor(this.node.color);
+        
         this._nativeDisplay.setDBEventCallback(function(eventObject) {
             this._eventTarget.emit(eventObject.type, eventObject);
         });
@@ -473,6 +475,12 @@
         
         if (this.animationName) {
             this.playAnimation(this.animationName, this.playTimes);
+        }
+    };
+
+    armatureDisplayProto._updateColor = function () {
+        if (this._nativeDisplay) {
+            this._nativeDisplay.setColor(this.node.color);
         }
     };
 
@@ -591,11 +599,6 @@
 
         let node = this.node;
         if (!node) return;
-
-        if (this.__preColor__ === undefined || !node.color.equals(this.__preColor__)) {
-            nativeDisplay.setColor(node.color);
-            this.__preColor__ = node.color;
-        }
 
         if (!this.isAnimationCached() && this._debugDraw && this.debugBones) {
 

--- a/engine/jsb-spine-skeleton.js
+++ b/engine/jsb-spine-skeleton.js
@@ -336,6 +336,8 @@
         nativeSkeleton.setTimeScale(this.timeScale);
         nativeSkeleton.setBatchEnabled(this.enableBatch);
         nativeSkeleton.bindNodeProxy(this.node._proxy);
+        nativeSkeleton.setColor(this.node.color);
+
         this._skeleton = nativeSkeleton.getSkeleton();
 
         // init skeleton listener
@@ -347,6 +349,12 @@
         this._disposeListener && this.setDisposeListener(this._disposeListener);
 
         this._activateMaterial();
+    };
+
+    skeleton._updateColor = function () {
+        if (this._nativeSkeleton) {
+            this._nativeSkeleton.setColor(this.node.color);
+        }
     };
 
     skeleton.setAnimationStateData = function (stateData) {
@@ -393,11 +401,6 @@
 
         let node = this.node;
         if (!node) return;
-
-        if (this.__preColor__ === undefined || !node.color.equals(this.__preColor__)) {
-            nativeSkeleton.setColor(node.color);
-            this.__preColor__ = node.color;
-        }
         
         if (!this.isAnimationCached() && (this.debugBones || this.debugSlots || this.debugMesh) && this._debugRenderer) {
             


### PR DESCRIPTION
优化原生Dragonbones 和 Spine 颜色更新逻辑
旧的逻辑是2.2 之前版本，由于颜色无法知道何时更新，所以需要不断判断，性能较差。
2.2之后，可以通过_updateColor获得颜色更新的回调。