### PR TITLE
refine spine reset logic

### DIFF
--- a/engine/jsb-spine-skeleton.js
+++ b/engine/jsb-spine-skeleton.js
@@ -65,13 +65,18 @@
     let skeletonCacheMgr = spine.SkeletonCacheMgr.getInstance();
     spine.skeletonCacheMgr = skeletonCacheMgr;
     skeletonDataProto.destroy = function () {
+        this.reset();
+        skeletonCacheMgr.removeSkeletonCache(this._uuid);
+        cc.Asset.prototype.destroy.call(this);
+    };
+
+    skeletonDataProto.reset = function () {
         if (this._skeletonCache) {
             spine.disposeSkeletonData(this._uuid);
             this._jsbTextures = null;
             this._skeletonCache = null;
         }
-        skeletonCacheMgr.removeSkeletonCache(this._uuid);
-        cc.Asset.prototype.destroy.call(this);
+        this._atlasCache = null;
     };
 
     skeletonDataProto.getRuntimeData = function () {


### PR DESCRIPTION
原生层的reset逻辑与h5层稍有不同，需要释放对原生骨骼数据的引用。
原本只在destroy的时候这么做，但若用户对Skeletondata赋予不同的骨骼资源，那么就有内存泄漏的风险。
当然原则上不鼓励对Skeletondata赋予不同的骨骼资源，也没有必要，这里只是消除隐患。

