### PR TITLE
fix video full screen when set url

### DIFF
--- a/engine/jsb-videoplayer.js
+++ b/engine/jsb-videoplayer.js
@@ -167,6 +167,7 @@
         this._loadedmeta = false;
 
         video.setURL(this._url);
+        this._forceUpdate = true;
     };
 
     _p.getURL = function() {
@@ -332,7 +333,8 @@
         if (!this._video || !this._visible) return;
 
         node.getWorldMatrix(_worldMat);
-        if (this._m00 === _worldMat.m[0] && this._m01 === _worldMat.m[1] &&
+        if (!this._forceUpdate &&
+            this._m00 === _worldMat.m[0] && this._m01 === _worldMat.m[1] &&
             this._m04 === _worldMat.m[4] && this._m05 === _worldMat.m[5] &&
             this._m12 === _worldMat.m[12] && this._m13 === _worldMat.m[13] &&
             this._w === node._contentSize.width && this._h === node._contentSize.height) {
@@ -377,6 +379,7 @@
 
         var height = cc.view.getFrameSize().height;
         this._video.setFrame(tx, height - finalHeight - ty, finalWidth, finalHeight);
+        this._forceUpdate = false;
     };
 
     _impl.EventType = {


### PR DESCRIPTION
changeLog:
- 修复原生 videoPlayer 更换 url 之后，会自动切全屏的问题

原因是之前有 forceUpdate 的关系，每帧都在 updateMatrix, 所以之前没有这个问题
现在原生的实现是，每次调 video.setUrl 都会默认转全屏，需要再 forceUpdate 一次