### PR TITLE
Fix the problem when the MeshBuffer is switched on the native platform.

### DIFF
--- a/engine/assemblers/assembler.js
+++ b/engine/assemblers/assembler.js
@@ -94,6 +94,14 @@ let Assembler = {
 
     updateColor(comp, color) {
         this._dirtyPtr[0] |= FLAG_VERTICES_OPACITY_CHANGED;
+    },
+
+    updateIADatas (iaIndex, meshIndex) {
+        // When the MeshBuffer is switched, it is necessary to synchronize the iaData of the native assembler.
+        this.updateMeshIndex(iaIndex, meshIndex);
+        let materials = this._renderComp.sharedMaterials; 
+        let material = materials[iaIndex] || materials[0];
+        this.updateMaterial(iaIndex, material);
     }
 };
 

--- a/engine/assemblers/graphics-assembler.js
+++ b/engine/assemblers/graphics-assembler.js
@@ -32,3 +32,11 @@ proto.fill = function (graphics) {
     let buffer = this._buffer;
     buffer.meshbuffer.used(buffer.vertexStart, buffer.indiceStart);
 }
+
+let _updateIADatas = proto.updateIADatas;
+proto.updateIADatas = function (iaIndex, meshIndex) {
+    _updateIADatas.call(this, iaIndex, meshIndex);
+    // Reset vertexStart and indiceStart when buffer is switched.
+    this._buffer.vertexStart = 0;
+    this._buffer.indiceStart = 0;
+}

--- a/engine/scene/mesh-buffer.js
+++ b/engine/scene/mesh-buffer.js
@@ -100,6 +100,8 @@
     MeshBuffer.checkAndSwitchBuffer = function(vertexCount) {
         if (this.vertexOffset + vertexCount > 65535) {
             this.switchBuffer();
+            if (!this._nativeAssembler) return;
+            this._nativeAssembler.updateIADatas && this._nativeAssembler.updateIADatas(this._arrOffset, this._arrOffset);
         }
     };
 
@@ -161,7 +163,12 @@
         this.indiceOffset = 0;
         this.vertexOffset = 0;
 
-        this.used(0, 0);
+        if (!this._nativeAssembler) return;
+
+        for (let i = 0, len = this._vDatas.length; i < len; i++) {
+            this._nativeAssembler.updateVerticesRange(i, 0, 0);
+            this._nativeAssembler.updateIndicesRange(i, 0, 0);
+        }
     };
 
     MeshBuffer.destroy = function() {


### PR DESCRIPTION
Re: cocos-creator/2d-tasks#2078

**问题反馈：**

https://forum.cocos.org/t/v2-20-mask/85523/13?u=cary

之前因为 Graphics 同步绘制顶点数量超过65535时，会重新创建MeshBuffer导致原生平台之前绘制的内容被重置，故修改为使用同一个MeshBuffer，adapter层会重写MeshBuffer使用RenderDataList来进行buffer数据切换。但是之前更新完RenderDataList之后，没有同步Assembler的IAData，导致切换之后新的数据不会被渲染。

**修改说明：**

当MeshBuffer由于顶点数量过多进行buffer切换的时候，同步更新Assembler的IAData，在MeshBuffer重置的时候，重置所有的vData数据。

**关联PR:** https://github.com/cocos-creator/cocos2d-x-lite/pull/1935