### PR TITLE
Fixed a crash when Mask dynamically switched type.

### DIFF
--- a/engine/assemblers/mask-assembler.js
+++ b/engine/assemblers/mask-assembler.js
@@ -52,7 +52,7 @@ cc.js.mixin(proto, {
 
         mask.node._renderFlag |= cc.RenderFlow.FLAG_UPDATE_RENDER_DATA;
     }
-}, renderer.MaskAssembler.prototype);
+}, renderer.MaskAssembler.prototype, {constructor: cc.Mask.__assembler__});
 
 let originCreateGraphics = cc.Mask.prototype._createGraphics;
 let originRemoveGraphics = cc.Mask.prototype._removeGraphics;

--- a/engine/assemblers/mask-assembler.js
+++ b/engine/assemblers/mask-assembler.js
@@ -31,6 +31,9 @@ const graphicsAssembler = cc.Graphics.__assembler__.prototype;
 
 let proto = cc.Mask.__assembler__.prototype;
 let _updateRenderData = proto.updateRenderData;
+// Avoid constructor being overridden.
+renderer.MaskAssembler.prototype.constructor = cc.Mask.__assembler__;
+
 cc.js.mixin(proto, {
     _extendNative () {
         renderer.MaskAssembler.prototype.ctor.call(this);
@@ -52,7 +55,7 @@ cc.js.mixin(proto, {
 
         mask.node._renderFlag |= cc.RenderFlow.FLAG_UPDATE_RENDER_DATA;
     }
-}, renderer.MaskAssembler.prototype, {constructor: cc.Mask.__assembler__});
+}, renderer.MaskAssembler.prototype);
 
 let originCreateGraphics = cc.Mask.prototype._createGraphics;
 let originRemoveGraphics = cc.Mask.prototype._removeGraphics;


### PR DESCRIPTION
问题反馈：

![image](https://user-images.githubusercontent.com/39078800/69710045-8fb47d80-1139-11ea-9a60-a526541a5c03.png)

因为adapter层覆盖了原型的constructor，resetAssembler时导致Assembler.init里面判定constructor时不一致，重新创建了新的Assembler。