### PR TITLE
Fixed the opacity error of MotionStreak on native.

### DIFF
--- a/engine/assemblers/motion-streak.js
+++ b/engine/assemblers/motion-streak.js
@@ -8,6 +8,7 @@ cc.js.mixin(proto, {
 
         this.setUseModel(false);
         this.ignoreWorldMatrix();
+        this.ignoreOpacityFlag();
     },
     update (comp, dt) {
         comp.node._updateWorldMatrix();


### PR DESCRIPTION
这个PR：https://github.com/cocos-creator/cocos2d-x-lite/pull/1945 修改导致。

更新顶点数据的时候会重置OPCITY_FLAG，MotionStreak有自己的颜色参数，不需要关心节点的opacity