### PR TITLE
destroy webview and videoPlayer on components destruction

### DIFF
--- a/engine/jsb-videoplayer.js
+++ b/engine/jsb-videoplayer.js
@@ -124,8 +124,8 @@
     _p.removeDom = function () {
         let video = this._video;
         if (video) {
-            this._video.stop()
-            this._video.setVisible(false)
+            video.stop()
+            video.setVisible(false)
 
             let cbs = this.__eventListeners;
 
@@ -135,6 +135,8 @@
             cbs.pause = null;
             cbs.click = null;
             cbs.onCanPlay = null;
+
+            video.destroy();
         }
 
         this._video = null;

--- a/engine/jsb-webview.js
+++ b/engine/jsb-webview.js
@@ -98,6 +98,7 @@
             let cbs = this.__eventListeners;
             cbs.load = null;
             cbs.error = null;
+            iframe.destroy();
             this._iframe = null;
         }
     };


### PR DESCRIPTION
re: https://github.com/cocos-creator/2d-tasks/issues/2101


同步 pr： https://github.com/cocos-creator/cocos2d-x-lite/pull/1956

changeLog: 
- 支持原生平台 videoPlayer 和 webview 组件销毁时，及时销毁原生 js 对象