### PR TITLE
fix audio cache in audio downloader

### DIFF
--- a/engine/jsb-loader.js
+++ b/engine/jsb-loader.js
@@ -25,6 +25,57 @@
  ****************************************************************************/
 'use strict';
 
+/**
+ * JS Implementation of MurmurHash2
+ * 
+ * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
+ * @see http://github.com/garycourt/murmurhash-js
+ * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
+ * @see http://sites.google.com/site/murmurhash/
+ * 
+ * @param {string} str ASCII only
+ * @param {number} seed Positive integer only
+ * @return {number} 32-bit positive integer hash
+ */
+
+function murmurhash2_32_gc(str, seed) {
+    var
+      l = str.length,
+      h = seed ^ l,
+      i = 0,
+      k;
+    
+    while (l >= 4) {
+        k = 
+          ((str.charCodeAt(i) & 0xff)) |
+          ((str.charCodeAt(++i) & 0xff) << 8) |
+          ((str.charCodeAt(++i) & 0xff) << 16) |
+          ((str.charCodeAt(++i) & 0xff) << 24);
+      
+      k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));
+      k ^= k >>> 24;
+      k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));
+  
+      h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16)) ^ k;
+  
+      l -= 4;
+      ++i;
+    }
+    
+    switch (l) {
+    case 3: h ^= (str.charCodeAt(i + 2) & 0xff) << 16;
+    case 2: h ^= (str.charCodeAt(i + 1) & 0xff) << 8;
+    case 1: h ^= (str.charCodeAt(i) & 0xff);
+            h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));
+    }
+  
+    h ^= h >>> 13;
+    h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));
+    h ^= h >>> 15;
+  
+    return h >>> 0;
+}
+
 function downloadScript (item, callback) {
     require(item.url);
     return null;
@@ -54,8 +105,7 @@ audioDownloader.setOnTaskError((task, errorCode, errorCodeInternal, errorStr) =>
 
 function downloadAudio (item, callback) {
     if (/^http/.test(item.url)) {
-        let index = item.url.lastIndexOf('/');
-        let fileName = item.url.substr(index+1);
+        let fileName = murmurhash2_32_gc(item.url) + cc.path.extname(item.url);
         let storagePath = jsb.fileUtils.getWritablePath() + fileName;
 
         // load from local cache

--- a/engine/jsb-loader.js
+++ b/engine/jsb-loader.js
@@ -24,57 +24,7 @@
  THE SOFTWARE.
  ****************************************************************************/
 'use strict';
-
-/**
- * JS Implementation of MurmurHash2
- * 
- * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
- * @see http://github.com/garycourt/murmurhash-js
- * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
- * @see http://sites.google.com/site/murmurhash/
- * 
- * @param {string} str ASCII only
- * @param {number} seed Positive integer only
- * @return {number} 32-bit positive integer hash
- */
-
-function murmurhash2_32_gc(str, seed) {
-    var
-      l = str.length,
-      h = seed ^ l,
-      i = 0,
-      k;
-    
-    while (l >= 4) {
-        k = 
-          ((str.charCodeAt(i) & 0xff)) |
-          ((str.charCodeAt(++i) & 0xff) << 8) |
-          ((str.charCodeAt(++i) & 0xff) << 16) |
-          ((str.charCodeAt(++i) & 0xff) << 24);
-      
-      k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));
-      k ^= k >>> 24;
-      k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));
-  
-      h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16)) ^ k;
-  
-      l -= 4;
-      ++i;
-    }
-    
-    switch (l) {
-    case 3: h ^= (str.charCodeAt(i + 2) & 0xff) << 16;
-    case 2: h ^= (str.charCodeAt(i + 1) & 0xff) << 8;
-    case 1: h ^= (str.charCodeAt(i) & 0xff);
-            h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));
-    }
-  
-    h ^= h >>> 13;
-    h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));
-    h ^= h >>> 15;
-  
-    return h >>> 0;
-}
+const jsbUtils = require('./jsb-utils');
 
 function downloadScript (item, callback) {
     require(item.url);
@@ -105,7 +55,7 @@ audioDownloader.setOnTaskError((task, errorCode, errorCodeInternal, errorStr) =>
 
 function downloadAudio (item, callback) {
     if (/^http/.test(item.url)) {
-        let fileName = murmurhash2_32_gc(item.url) + cc.path.extname(item.url);
+        let fileName = jsbUtils.murmurhash2_32_gc(item.url) + cc.path.extname(item.url);
         let storagePath = jsb.fileUtils.getWritablePath() + fileName;
 
         // load from local cache

--- a/engine/jsb-utils.js
+++ b/engine/jsb-utils.js
@@ -3,8 +3,6 @@ const jsbUtils = {
     Copyright (c) 2011 Gary Court
    
     http://github.com/garycourt/murmurhash-js
-   
-    Copyright (c) 2011 Gary Court
 
     Permission is hereby granted, free of charge, to any person obtaining a copy 
     of this software and associated documentation files (the "Software"), to deal 

--- a/engine/jsb-utils.js
+++ b/engine/jsb-utils.js
@@ -2,14 +2,9 @@ const jsbUtils = {
     /**
      * JS Implementation of MurmurHash2
      *
-     * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
-     * @see http://github.com/garycourt/murmurhash-js
-     * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
-     * @see http://sites.google.com/site/murmurhash/
-     *
-     * @param {string} str ASCII only
-     * @param {number} seed Positive integer only
-     * @return {number} 32-bit positive integer hash
+     * Author: Gary Court
+     * Homepage: http://github.com/garycourt/murmurhash-js
+     * Licensed under the MIT license.
      */
     murmurhash2_32_gc (str, seed) {
         var

--- a/engine/jsb-utils.js
+++ b/engine/jsb-utils.js
@@ -1,11 +1,28 @@
 const jsbUtils = {
-    /**
-     * JS Implementation of MurmurHash2
-     *
-     * Author: Gary Court
-     * Homepage: http://github.com/garycourt/murmurhash-js
-     * Licensed under the MIT license.
-     */
+    /****************************************************************************
+    Copyright (c) 2011 Gary Court
+   
+    http://github.com/garycourt/murmurhash-js
+   
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated engine source code (the "Software"), a limited,
+     worldwide, royalty-free, non-assignable, revocable and non-exclusive license
+    to use Cocos Creator solely to develop games on your target platforms. You shall
+     not use Cocos Creator software for developing other software or tools that's
+     used for developing games. You are not granted to publish, distribute,
+     sublicense, and/or sell copies of Cocos Creator.
+   
+    The software or tools in this License Agreement are licensed, not sold.
+    Xiamen Yaji Software Co., Ltd. reserves all rights not expressly granted to you.
+   
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+    ****************************************************************************/
     murmurhash2_32_gc (str, seed) {
         var
         l = str.length,

--- a/engine/jsb-utils.js
+++ b/engine/jsb-utils.js
@@ -1,0 +1,54 @@
+const jsbUtils = {
+    /**
+     * JS Implementation of MurmurHash2
+     *
+     * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
+     * @see http://github.com/garycourt/murmurhash-js
+     * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
+     * @see http://sites.google.com/site/murmurhash/
+     *
+     * @param {string} str ASCII only
+     * @param {number} seed Positive integer only
+     * @return {number} 32-bit positive integer hash
+     */
+    murmurhash2_32_gc (str, seed) {
+        var
+        l = str.length,
+        h = seed ^ l,
+        i = 0,
+        k;
+
+        while (l >= 4) {
+            k =
+            ((str.charCodeAt(i) & 0xff)) |
+            ((str.charCodeAt(++i) & 0xff) << 8) |
+            ((str.charCodeAt(++i) & 0xff) << 16) |
+            ((str.charCodeAt(++i) & 0xff) << 24);
+
+        k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));
+        k ^= k >>> 24;
+        k = (((k & 0xffff) * 0x5bd1e995) + ((((k >>> 16) * 0x5bd1e995) & 0xffff) << 16));
+
+        h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16)) ^ k;
+
+        l -= 4;
+        ++i;
+        }
+
+        switch (l) {
+        case 3: h ^= (str.charCodeAt(i + 2) & 0xff) << 16;
+        case 2: h ^= (str.charCodeAt(i + 1) & 0xff) << 8;
+        case 1: h ^= (str.charCodeAt(i) & 0xff);
+                h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));
+        }
+
+        h ^= h >>> 13;
+        h = (((h & 0xffff) * 0x5bd1e995) + ((((h >>> 16) * 0x5bd1e995) & 0xffff) << 16));
+        h ^= h >>> 15;
+
+        return h >>> 0;
+    },
+
+};
+
+module.exports = jsbUtils;

--- a/engine/jsb-utils.js
+++ b/engine/jsb-utils.js
@@ -4,24 +4,24 @@ const jsbUtils = {
    
     http://github.com/garycourt/murmurhash-js
    
-    Permission is hereby granted, free of charge, to any person obtaining a copy
-    of this software and associated engine source code (the "Software"), a limited,
-     worldwide, royalty-free, non-assignable, revocable and non-exclusive license
-    to use Cocos Creator solely to develop games on your target platforms. You shall
-     not use Cocos Creator software for developing other software or tools that's
-     used for developing games. You are not granted to publish, distribute,
-     sublicense, and/or sell copies of Cocos Creator.
-   
-    The software or tools in this License Agreement are licensed, not sold.
-    Xiamen Yaji Software Co., Ltd. reserves all rights not expressly granted to you.
-   
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    THE SOFTWARE.
+    Copyright (c) 2011 Gary Court
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy 
+    of this software and associated documentation files (the "Software"), to deal 
+    in the Software without restriction, including without limitation the rights 
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+    copies of the Software, and to permit persons to whom the Software is furnished 
+    to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all 
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     ****************************************************************************/
     murmurhash2_32_gc (str, seed) {
         var


### PR DESCRIPTION
changeLog:
- 修复原生 cc.loader.load 加载同名的不同网络音频时，会使用本地音频缓存的问题

相关论坛反馈： https://forum.cocos.org/t/cc-loader-load/86932/5