### PR TITLE
particle native sync js modify

### DIFF
--- a/engine/jsb-particle.js
+++ b/engine/jsb-particle.js
@@ -251,6 +251,8 @@
         this._simulator.updateUVs(this._renderSpriteFrame.uv);
         this._syncAspect();
         this._simulator.aspectRatio = this._aspectRatio || 1.0;
+        this._updateMaterial();
+        this.markForRender(true);
     };
 
     let _updateMaterial = PSProto._updateMaterial;


### PR DESCRIPTION
https://github.com/cocos-creator/engine/pull/5931

2.3 由于材质系统修改，新引用的渲染问题（第一帧渲染错误）
贴图还未加载完成时，开始渲染造成。
