### PR TITLE
V2.3.0 tiledmap refine update material logic

### DIFF
--- a/engine/jsb-tiledmap.js
+++ b/engine/jsb-tiledmap.js
@@ -49,6 +49,17 @@
         }
     };
 
+    // override _activateMaterial to upload hash value to native
+    let _activateMaterial = TiledLayer._activateMaterial;
+    TiledLayer._activateMaterial = function () {
+        _activateMaterial.call(this);
+        let materials = this._materials;
+        for (let i = 0; i < materials.length; i++) {
+            let m = materials[i];
+            if (m) m.getHash();
+        }
+    };
+
     // tiledmap buffer
     let TiledMapBuffer = cc.TiledMapBuffer.prototype;
     TiledMapBuffer._updateOffset = function () {
@@ -153,12 +164,6 @@
 
         updateRenderData (comp) {
             if (!comp._modelBatcherDelegate) {
-                let materials = this._renderComp._materials;
-                for (let i = 0; i < materials.length; i++) {
-                    let m = materials[i];
-                    if (m) m.getHash();
-                }
-
                 comp._buffer = new cc.TiledMapBuffer(null, cc.gfx.VertexFormat.XY_UV_Color);
                 comp._renderDataList = new cc.TiledMapRenderDataList();
                 comp._modelBatcherDelegate = new ModelBatcherDelegate();


### PR DESCRIPTION
把更新hash的逻辑，挪至更新材质的接口处，当复用tiledmap，更新材质时，hash才能同步更新。
关联issue：https://github.com/cocos-creator/2d-tasks/issues/2225