### PR TITLE
Spine track event interface issue

### DIFF
--- a/engine/jsb-spine-skeleton.js
+++ b/engine/jsb-spine-skeleton.js
@@ -167,6 +167,15 @@
         });
     };
 
+    // The methods are added to be compatibility with old versions.
+    animation.setTrackCompleteListener = function (trackEntry, listener) {
+        this._trackCompeleteListener = listener;
+        this.setTrackCompleteListenerNative(trackEntry, function (trackEntryNative) {
+            let loopCount = Math.floor(trackEntryNative.trackTime / trackEntryNative.animationEnd);
+            this._trackCompeleteListener && this._trackCompeleteListener(trackEntryNative, loopCount);
+        });
+    };
+
     // Temporary solution before upgrade the Spine API
     animation.setAnimationListener = function (target, callback) {
         this._target = target;


### PR DESCRIPTION
高版本的spine库对于track event complete事件没有loopCount参数，这里做下适配
关联pr：https://github.com/cocos-creator/cocos2d-x-lite/pull/2033