### PR TITLE
V2.3.0 fix skeleton new material issue

### DIFF
--- a/engine/jsb-dragonbones.js
+++ b/engine/jsb-dragonbones.js
@@ -462,8 +462,8 @@ import { RSA_NO_PADDING } from "constants";
     armatureDisplayProto._updateMaterial = function() {
         _updateMaterial.call(this);
         this._assembler && this._assembler.clearEffect();
-        if (this._nativeDisplay) {
-            let baseMaterial = this.getMaterial(0);
+        let baseMaterial = this.getMaterial(0);
+        if (this._nativeDisplay && baseMaterial) {
             let originHash = baseMaterial.effect.getHash();
             let id = _materialHash2IDMap[originHash] || _materialId++;
             _materialHash2IDMap[originHash] = id;

--- a/engine/jsb-spine-skeleton.js
+++ b/engine/jsb-spine-skeleton.js
@@ -307,8 +307,8 @@
     skeleton._updateMaterial = function() {
         _updateMaterial.call(this);
         this._assembler && this._assembler.clearEffect();
-        if (this._nativeSkeleton) {
-            let baseMaterial = this.getMaterial(0);
+        let baseMaterial = this.getMaterial(0);
+        if (this._nativeSkeleton && baseMaterial) {
             let originHash = baseMaterial.effect.getHash();
             let id = _materialHashMap[originHash] || _materialId++;
             _materialHashMap[originHash] = id;


### PR DESCRIPTION
当节点还未添加至节点树时，材质未初始化，则可能出现空的情况