### PR TITLE
fix module management

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -125,27 +125,27 @@
   {
     "name": "EditBox",
     "entries": [
-      "./dist/engine/jsb-editbox.js",
-      "./dist/engine/rt_input.js"
+      "./engine/jsb-editbox.js",
+      "./engine/rt_input.js"
     ],
     "dependencies": ["WebGL Renderer"]
   },
   {
     "name": "VideoPlayer",
     "entries": [
-      "./dist/engine/jsb-videoplayer.js"
+      "./engine/jsb-videoplayer.js"
     ]
   },
   {
     "name": "WebView",
     "entries": [
-      "./dist/engine/jsb-webview.js"
+      "./engine/jsb-webview.js"
     ]
   },
   {
     "name": "Audio",
     "entries": [
-      "./dist/engine/jsb-audio.js"
+      "./engine/jsb-audio.js"
     ]
   },
   {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2171

changeLog:
- 修复部分 jsb-adapter 模块无法被剔除的问题（包括 webview）