### PR TITLE
unregister event listeners when editbox destoyed

### DIFF
--- a/engine/jsb-editbox.js
+++ b/engine/jsb-editbox.js
@@ -114,9 +114,6 @@
 
             function onComplete (res) {
                 self.endEditing();
-                jsb.inputBox.offConfirm(onConfirm);
-                jsb.inputBox.offInput(onInput);
-                jsb.inputBox.offComplete(onComplete);
             }
 
             jsb.inputBox.onInput(onInput);
@@ -143,6 +140,9 @@
         },
 
         endEditing () {
+            jsb.inputBox.offConfirm();
+            jsb.inputBox.offInput();
+            jsb.inputBox.offComplete();
             this._editing = false;
             if (!cc.sys.isMobile) {
                 this._delegate._showLabels();


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2260

changeLog:
- 修复原生平台 EditBox 节点被销毁后，触屏会报错的问题

被 disable 时，会执行 endEditing，但是不会调到 onComplete 回调