### PR TITLE
fix editbox negative maxLength

### DIFF
--- a/engine/jsb-editbox.js
+++ b/engine/jsb-editbox.js
@@ -32,6 +32,7 @@
     const KeyboardReturnType = EditBox.KeyboardReturnType;
     const InputMode = EditBox.InputMode;
     const InputFlag = EditBox.InputFlag;
+    const MAX_VALUE = 65535;
 
     let worldMat = new cc.Mat4(),
         cameraMat = new cc.Mat4();
@@ -93,7 +94,7 @@
             let delegate = this._delegate;
             let multiline = (delegate.inputMode === InputMode.ANY);
             let rect = this._getRect();
-
+            let maxLength = (delegate.maxLength < 0 ? MAX_VALUE : delegate.maxLength)
             let inputTypeString = getInputType(delegate.inputMode);
             if (delegate.inputFlag === InputFlag.PASSWORD) {
                 inputTypeString = 'password';
@@ -125,7 +126,7 @@
             }
             jsb.inputBox.show({
                 defaultValue: delegate._string,
-                maxLength: delegate.maxLength,
+                maxLength: maxLength,
                 multiple: multiline,
                 confirmHold: false,
                 confirmType: getKeyboardReturnType(delegate.returnType),


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/2321

changeLog:
- 修复 maxLength 为负数时，editBox 无法输入的问题

安卓没有处理负数的情况，统一在 js 层上做处理吧