### PR TITLE
Handle error event when image download fail

### DIFF
--- a/builtin/jsb-adapter/HTMLImageElement.js
+++ b/builtin/jsb-adapter/HTMLImageElement.js
@@ -23,10 +23,14 @@ class HTMLImageElement extends HTMLElement {
         jsb.loadImage(src, (info) => {
             if (!info) {
                 this._data = null;
+                return;
+            } else if (info && info.errorMsg) {
+                this._data = null;
                 var event = new Event('error');
                 this.dispatchEvent(event);
                 return;
             }
+
             this.width = this.naturalWidth = info.width;
             this.height = this.naturalHeight = info.height;
             this._data = info.data;

--- a/engine/jsb-loader.js
+++ b/engine/jsb-loader.js
@@ -94,9 +94,12 @@ function loadAudio (item, callback) {
 function downloadImage(item, callback) {
     let img = new Image();
     img.src = item.url;
-    img.onload = function(info) {
+    img.onload = function (info) {
         callback(null, img);
-    }
+    };
+    img.onerror = function (event) {
+        callback(event, null);
+    };
     // Don't return anything to use async loading.
 }
 

--- a/engine/jsb-loader.js
+++ b/engine/jsb-loader.js
@@ -98,7 +98,7 @@ function downloadImage(item, callback) {
         callback(null, img);
     };
     img.onerror = function (event) {
-        callback(event, null);
+        callback(new Error('load image fail:' + img.src), null);
     };
     // Don't return anything to use async loading.
 }


### PR DESCRIPTION
修复下载图片错误无回调的bug
经查，native 返回 info 为空的时候并不是错误，而是当设置 src 为空的时候返回的值，下载的错误没有返回，在 c++ 层补上

https://github.com/cocos-creator/cocos2d-x-lite/pull/2077

https://github.com/cocos-creator/2d-tasks/issues/2160

