### PR TITLE
fix editBox maxLength slice on native

### DIFF
--- a/engine/jsb-editbox.js
+++ b/engine/jsb-editbox.js
@@ -105,9 +105,6 @@
             }
 
             function onInput (res) {
-                if (res.value.length > delegate.maxLength) {
-                    res.value = res.value.slice(0, delegate.maxLength);
-                }
                 if (delegate._string !== res.value) {
                     delegate.editBoxTextChanged(res.value);
                 }


### PR DESCRIPTION
Re：https://github.com/cocos-creator/2d-tasks/issues/2416

changeLog:
- 修复原生平台 editbox maxLength 为负数时，裁剪错误的问题

同步小游戏平台 ： https://github.com/cocos-creator-packages/adapters/pull/81