### PR TITLE
restart memory leak 

### DIFF
--- a/engine/jsb-game.js
+++ b/engine/jsb-game.js
@@ -24,6 +24,10 @@
  ****************************************************************************/
 
 cc.game.restart = function () {
+    // Need to clear scene, or native object destructor won't be invoke.
+    cc.director.getScene().destroy();
+    cc.Object._deferredDestroy();
+
     __restartVM();
 };
 


### PR DESCRIPTION
restart时，native对象的析构没有被调用，需手动destroy场景

issuer：https://github.com/cocos-creator/2d-tasks/issues/2537