### PR TITLE
fix wroing canvas clientWidth clientHeight and boundingClientRect on  3D branch

### DIFF
--- a/builtin/jsb-adapter/HTMLCanvasElement.js
+++ b/builtin/jsb-adapter/HTMLCanvasElement.js
@@ -101,11 +101,11 @@ class HTMLCanvasElement extends HTMLElement {
     }
 
     get clientWidth() {
-        return this._width / window.devicePixelRatio;
+        return window.innerWidth;
     }
 
     get clientHeight() {
-        return this._height / window.devicePixelRatio;
+        return window.innerHeight;
     }
 
     get data() {
@@ -116,7 +116,7 @@ class HTMLCanvasElement extends HTMLElement {
     }
 
     getBoundingClientRect() {
-        return new DOMRect(0, 0, this._width / window.devicePixelRatio, this._height / window.devicePixelRatio);
+        return new DOMRect(0, 0, window.innerWidth, window.innerHeight);
     }
 
     requestPointerLock() {


### PR DESCRIPTION
同步 2d 的修复 https://github.com/cocos-creator-packages/jsb-adapter/pull/269

> changeLog:
修复原生平台获取 canvas clientWidth clientHeight boundingClientRect 错误的问题
该问题会导致 window resize 之后，鼠标触摸位置不正确
_width 和 _height 属性在屏幕适配之前是不正确的，不能用这两个值来做相关计算