### PR TITLE
update editBox rect when window resized on Win32 and Mac

### DIFF
--- a/builtin/jsb_input.js
+++ b/builtin/jsb_input.js
@@ -97,6 +97,9 @@ jsb.inputBox = {
 	hide: function() {
 		jsb.hideInputBox();
 	},
+	updateRect (x, y, width, height) {
+		jsb.updateInputBoxRect(x, y, width, height);
+	},
 };
 
 jsb.onTextInput = function(eventName, text) {

--- a/engine/jsb-editbox.js
+++ b/engine/jsb-editbox.js
@@ -89,6 +89,11 @@
             this._delegate = delegate;
         },
 
+        _onResize () {
+            let { x, y, width, height } = this._getRect();
+            jsb.inputBox.updateRect(x, y, width, height);
+        },
+
         beginEditing () {
             let self = this;
             let delegate = this._delegate;
@@ -135,6 +140,9 @@
             });
             this._editing = true;
             delegate.editBoxEditingDidBegan();
+            if (!cc.sys.isMobile) {
+                cc.view.on('canvas-resize', this._onResize, this);
+            }
         },
 
         endEditing () {
@@ -147,6 +155,9 @@
             }
             jsb.inputBox.hide();
             this._delegate.editBoxEditingDidEnded();
+            if (!cc.sys.isMobile) {
+                cc.view.off('canvas-resize', this._onResize, this);
+            }
         },
 
         _getRect () {


### PR DESCRIPTION
resolve https://github.com/cocos-creator/2d-tasks/issues/2561

changeLog:
- 修复 win32 和 mac 平台上，EditBox 在窗口 resize 时，没有更新位置的问题

相关 pr: https://github.com/cocos-creator/cocos2d-x-lite/pull/2421