### PR TITLE
fix touch point position error on iOS.

### DIFF
--- a/engine/jsb-game.js
+++ b/engine/jsb-game.js
@@ -41,8 +41,8 @@ jsb.onResume = function () {
 
 function resize (size) {
     // size should be the css style
-    size.width /= cc.view._devicePixelRatio;
-    size.height /= cc.view._devicePixelRatio;
+    size.width /= window.devicePixelRatio;
+    size.height /= window.devicePixelRatio;
     window.resize(size.width, size.height);
 }
 


### PR DESCRIPTION
avoid to set a no correct size for window, because cc.view._devicePixelRatio maybe no init.