### PR TITLE
fix Assembler2D offset hardcode, so custom vfmt in custom assembler c…

### DIFF
--- a/engine/assemblers/assembler-2d.js
+++ b/engine/assemblers/assembler-2d.js
@@ -7,18 +7,23 @@ cc.Assembler2D.prototype.updateWorldVerts = function(comp) {
         vb = local[1],
         vt = local[3];
   
+    let floatsPerVert = this.floatsPerVert;
+    let vertexOffset = 0;
     // left bottom
-    verts[0] = vl;
-    verts[1] = vb;
+    verts[vertexOffset] = vl;
+    verts[vertexOffset + 1] = vb;
+    vertexOffset += floatsPerVert;
     // right bottom
-    verts[5] = vr;
-    verts[6] = vb;
+    verts[vertexOffset] = vr;
+    verts[vertexOffset + 1] = vb;
+    vertexOffset += floatsPerVert;
     // left top
-    verts[10] = vl;
-    verts[11] = vt;
+    verts[vertexOffset] = vl;
+    verts[vertexOffset + 1] = vt;
+    vertexOffset += floatsPerVert;
     // right top
-    verts[15] = vr;
-    verts[16] = vt;
+    verts[vertexOffset] = vr;
+    verts[vertexOffset + 1] = vt;
 };
 
 let _updateColor = cc.Assembler2D.prototype.updateColor;


### PR DESCRIPTION
…an reuse this function

Changes:
 * 修改Assembler2D 计算顶点世界坐标时，始终认为floatsPerVert == 5的硬编码逻辑。方便Assembler自定义顶点格式时复用该逻辑。