### PR TITLE
Update jsb-cache-manager.js

### DIFF
--- a/engine/jsb-cache-manager.js
+++ b/engine/jsb-cache-manager.js
@@ -54,8 +54,8 @@ var cacheManager = {
     },
 
     init () {
-        this.cacheDir = getUserDataPath() + '/' + this.cacheDir;
-        var cacheFilePath = this.cacheDir + '/' + this.cachedFileName;
+        this.cacheDir = getUserDataPath()  + this.cacheDir;
+        var cacheFilePath = this.cacheDir  + this.cachedFileName;
         var result = readJsonSync(cacheFilePath);
         if (result instanceof Error || !result.version) {
             if (!(result instanceof Error)) rmdirSync(this.cacheDir, true);


### PR DESCRIPTION
fs.getWritablePath() alrady returns as "xxxxxx/" by default . adding slashes is inconvenient.