### PR TITLE
unregister event listeners when editbox destoyed

### DIFF
--- a/builtin/jsb_input.js
+++ b/builtin/jsb_input.js
@@ -97,6 +97,9 @@ jsb.inputBox = {
 	hide: function() {
 		jsb.hideInputBox();
 	},
+	updateRect (x, y, width, height) {
+		jsb.updateInputBoxRect(x, y, width, height);
+	},
 };
 
 jsb.onTextInput = function(eventName, text) {

--- a/engine/jsb-editbox.js
+++ b/engine/jsb-editbox.js
@@ -116,9 +116,6 @@
 
             function onComplete (res) {
                 self.endEditing();
-                jsb.inputBox.offConfirm(onConfirm);
-                jsb.inputBox.offInput(onInput);
-                jsb.inputBox.offComplete(onComplete);
             }
 
             jsb.inputBox.onInput(onInput);
@@ -146,6 +143,9 @@
         },
 
         endEditing () {
+            jsb.inputBox.offConfirm();
+            jsb.inputBox.offInput();
+            jsb.inputBox.offComplete();
             this._editing = false;
             if (!cc.sys.isMobile) {
                 this._delegate._showLabels();

--- a/engine/jsb-editbox.js
+++ b/engine/jsb-editbox.js
@@ -33,6 +33,7 @@
     const KeyboardReturnType = EditBox.KeyboardReturnType;
     const InputMode = EditBox.InputMode;
     const InputFlag = EditBox.InputFlag;
+    const MAX_VALUE = 65535;
 
     let worldMat = cc.mat4();
 
@@ -93,7 +94,6 @@
             let delegate = this._delegate;
             let multiline = (delegate.inputMode === InputMode.ANY);
             let rect = this._getRect();
-            this.setMaxLength(delegate.maxLength);
 
             let inputTypeString = getInputType(delegate.inputMode);
             if (delegate.inputFlag === InputFlag.PASSWORD) {
@@ -105,10 +105,6 @@
             }
 
             function onInput (res) {
-                if (res.value.length > self._maxLength) {
-                    res.value = res.value.slice(0, self._maxLength);
-                }
-
                 if (delegate.string !== res.value) {
                     delegate._editBoxTextChanged(res.value);
                 }
@@ -128,7 +124,7 @@
 
             jsb.inputBox.show({
                 defaultValue: delegate.string,
-                maxLength: self._maxLength,
+                maxLength: delegate.maxLength < 0 ? MAX_VALUE : delegate.maxLength,
                 multiple: multiline,
                 confirmHold: false,
                 confirmType: getKeyboardReturnType(delegate.returnType),
@@ -152,17 +148,6 @@
             }
             jsb.inputBox.hide();
             this._delegate._editBoxEditingDidEnded();
-        },
-
-        setMaxLength (maxLength) {
-            if (!isNaN(maxLength)) {
-                if (maxLength < 0) {
-                    //we can't set Number.MAX_VALUE to input's maxLength property
-                    //so we use a magic number here, it should works at most use cases.
-                    maxLength = 65535;
-                }
-                this._maxLength = maxLength;
-            }
         },
 
         _getRect () {

--- a/engine/jsb-editbox.js
+++ b/engine/jsb-editbox.js
@@ -89,6 +89,11 @@
             this._delegate = delegate;
         },
 
+        _onResize () {
+            let { x, y, width, height } = this._getRect();
+            jsb.inputBox.updateRect(x, y, width, height);
+        },
+
         beginEditing () {
             let self = this;
             let delegate = this._delegate;
@@ -136,6 +141,9 @@
             });
             this._editing = true;
             delegate._editBoxEditingDidBegan();
+            if (!cc.sys.isMobile) {
+                cc.view.on('canvas-resize', this._onResize, this);
+            }
         },
 
         endEditing () {
@@ -148,6 +156,9 @@
             }
             jsb.inputBox.hide();
             this._delegate._editBoxEditingDidEnded();
+            if (!cc.sys.isMobile) {
+                cc.view.off('canvas-resize', this._onResize, this);
+            }
         },
 
         _getRect () {


### PR DESCRIPTION
re: https://github.com/cocos-creator/3d-tasks/issues/4026

changeLog:
- remove setMaxLength method, sync from pr: https://github.com/cocos-creator-packages/jsb-adapter/pull/238
- unregister event listners when editBox destroyed, for details : https://github.com/cocos-creator-packages/jsb-adapter/pull/234
- update editBox rect when window resized on Win32 and Mac, sync from pr: https://github.com/cocos-creator-packages/jsb-adapter/pull/286, related pr: https://github.com/cocos-creator/cocos2d-x-lite/pull/2680