### PR TITLE
Add placeholder in Android native Editbox.

### DIFF
--- a/engine/jsb-editbox.js
+++ b/engine/jsb-editbox.js
@@ -128,6 +128,7 @@
             }
             jsb.inputBox.show({
                 defaultValue: delegate._string,
+                placeholder: delegate.placeholder,
                 maxLength: maxLength,
                 multiple: multiline,
                 confirmHold: false,


### PR DESCRIPTION
#在 Android native 弹起的 Editbox 上添加 placeholder。Android 虚拟机效果如图：
![Jietu20200903-001412](https://user-images.githubusercontent.com/7514260/92009472-23774200-ed7b-11ea-9f74-c67882931e34.jpg)
