### PR TITLE
fix dragbone crash issue.

### DIFF
--- a/engine/jsb-dragonbones.js
+++ b/engine/jsb-dragonbones.js
@@ -400,16 +400,21 @@ const cacheManager = require('./jsb-cache-manager');
                 this.animationName = '';
             }
 
+            var oldArmature = this._armature;
             if (this._armature) {
                 if (!this.isAnimationCached()) {
                     this._factory.remove(this._armature);
                 }
-                this._armature.dispose();
                 this._armature = null;
             }
             this._nativeDisplay = null;
             
             this._refresh();
+            
+            if (oldArmature != this._armature) {
+                this._armature.dispose();
+            }
+            
             if (this._armature && !this.isAnimationCached()) {
                 this._factory.add(this._armature);
             }


### PR DESCRIPTION
Don't dispose armature early, because dispose is an asynchronous method, this may dispose a loading Animation, then cause crash.

forum: https://forum.cocos.org/t/cocos-creator-v2-4-3-rc-5/96344/515?u=endevil

