### PR TITLE
refine audioEngine effect

### DIFF
--- a/engine/jsb-audio.js
+++ b/engine/jsb-audio.js
@@ -209,7 +209,8 @@ let handleVolume  = function (volume) {
         var length = _effect.idArray.length;
         for (var i = 0; i < length; i++) {
             if (_effect.idArray[i] === id) {
-                _effect.idArray.slice(i, id);
+                _effect.idArray.splice(i, id);
+                break;
             }
         }
         return audioEngine.stop(id);

--- a/engine/jsb-audio.js
+++ b/engine/jsb-audio.js
@@ -119,6 +119,7 @@ let handleVolume  = function (volume) {
         volume: 1
     };
     var _effect = {
+        idArray: [],
         volume: 1
     };
 
@@ -174,7 +175,9 @@ let handleVolume  = function (volume) {
         return audioEngine.getState(_music.id) === audioEngine.AudioState.PLAYING;
     };
     audioEngine.playEffect = function (filePath, loop) {
-        return audioEngine.play(filePath, loop || false, _effect.volume);
+        var effectId = audioEngine.play(filePath, loop || false, _effect.volume);
+        _effect.idArray.push(effectId);
+        return effectId;
     };
     audioEngine.setEffectsVolume = function (volume) {
         _effect.volume = handleVolume(volume);
@@ -186,33 +189,35 @@ let handleVolume  = function (volume) {
         return audioEngine.pause(audioID);
     };
     audioEngine.pauseAllEffects = function () {
-        var musicPlay = audioEngine.getState(_music.id) === audioEngine.AudioState.PLAYING;
-        audioEngine.pauseAll();
-        if (musicPlay) {
-            audioEngine.resume(_music.id);
+        var length = _effect.idArray.length;
+        for (var i = 0; i < length; i++) {
+            audioEngine.pause(_effect.idArray[i]);
         }
     };
     audioEngine.resumeEffect = function (id) {
         audioEngine.resume(id);
     };
     audioEngine.resumeAllEffects = function () {
-        var musicPaused = audioEngine.getState(_music.id) === audioEngine.AudioState.PAUSED;
-        audioEngine.resumeAll();
-        if (musicPaused && audioEngine.getState(_music.id) === audioEngine.AudioState.PLAYING) {
-            audioEngine.pause(_music.id);
+        var length = _effect.idArray.length;
+        for (var i = 0; i < length; i++) {
+            audioEngine.resume(_effect.idArray[i]);
         }
     };
     audioEngine.stopEffect = function (id) {
+        var length = _effect.idArray.length;
+        for (var i = 0; i < length; i++) {
+            if (_effect.idArray[i] === id) {
+                _effect.idArray.slice(i, id);
+            }
+        }
         return audioEngine.stop(id);
     };
     audioEngine.stopAllEffects = function () {
-        var musicPlaying = audioEngine.getState(_music.id) === audioEngine.AudioState.PLAYING;
-        var currentTime = audioEngine.getCurrentTime(_music.id);
-        audioEngine.stopAll();
-        if (musicPlaying) {
-            _music.id = audioEngine.play(_music.clip, _music.loop);
-            audioEngine.setCurrentTime(_music.id, currentTime);
+        var length = _effect.idArray.length;
+        for (var i = 0; i < length; i++) {
+            audioEngine.stop(_effect.idArray[i]);
         }
+        _effect.idArray = [];
     };
 
     // Unnecessary on native platform

--- a/engine/jsb-audio.js
+++ b/engine/jsb-audio.js
@@ -209,7 +209,7 @@ let handleVolume  = function (volume) {
         var length = _effect.idArray.length;
         for (var i = 0; i < length; i++) {
             if (_effect.idArray[i] === id) {
-                _effect.idArray.splice(i, id);
+                _effect.idArray.splice(i, 1, id);
                 break;
             }
         }

--- a/engine/jsb-audio.js
+++ b/engine/jsb-audio.js
@@ -189,18 +189,20 @@ let handleVolume  = function (volume) {
         return audioEngine.pause(audioID);
     };
     audioEngine.pauseAllEffects = function () {
-        var length = _effect.idArray.length;
-        for (var i = 0; i < length; i++) {
-            audioEngine.pause(_effect.idArray[i]);
+        var musicPlay = audioEngine.getState(_music.id) === audioEngine.AudioState.PLAYING;
+        audioEngine.pauseAll();
+        if (musicPlay) {
+            audioEngine.resume(_music.id);
         }
     };
     audioEngine.resumeEffect = function (id) {
         audioEngine.resume(id);
     };
     audioEngine.resumeAllEffects = function () {
-        var length = _effect.idArray.length;
-        for (var i = 0; i < length; i++) {
-            audioEngine.resume(_effect.idArray[i]);
+        var musicPaused = audioEngine.getState(_music.id) === audioEngine.AudioState.PAUSED;
+        audioEngine.resumeAll();
+        if (musicPaused && audioEngine.getState(_music.id) === audioEngine.AudioState.PLAYING) {
+            audioEngine.pause(_music.id);
         }
     };
     audioEngine.stopEffect = function (id) {

--- a/engine/jsb-audio.js
+++ b/engine/jsb-audio.js
@@ -209,7 +209,7 @@ let handleVolume  = function (volume) {
         var length = _effect.idArray.length;
         for (var i = 0; i < length; i++) {
             if (_effect.idArray[i] === id) {
-                _effect.idArray.splice(i, 1, id);
+                _effect.idArray.splice(i, 1);
                 break;
             }
         }


### PR DESCRIPTION
RE：https://forum.cocos.org/t/stopalleffects/97889

在 ios 上，这样的用法没法让音频在播放后立即跳转到指定时间。
```
_music.id = audioEngine.play(_music.clip, _music.loop);
audioEngine.setCurrentTime(_music.id, currentTime);
```

而，android 上执行这段代码也会有明显的卡顿。

所以放弃这种方法。选择记录下每个 effectId，用它们对音效进行控制。