### PR TITLE
fix safe area change error

### DIFF
--- a/engine/jsb-safearea.js
+++ b/engine/jsb-safearea.js
@@ -20,7 +20,9 @@ if (SafeArea) {
         adaptSafeAreaChange(){
             if (CC_JSB && (cc.sys.os === cc.sys.OS_IOS || cc.sys.os === cc.sys.OS_ANDROID)) {
                 setTimeout(() => {
-                    this.updateArea();
+                    if (cc.isValid(this)) {
+                        this.updateArea();
+                    }
                 }, 200);
             }
         }


### PR DESCRIPTION
一些场景下，updateArea 执行时，对象可能已经被销毁，此处增加兜底判断